### PR TITLE
Add support for Scala 2.10.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
 scala:
+  - 2.10.6
   - 2.11.8
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ Requirements
 ================
 
 This library requires Spark 2.0+ (not tested for earlier version).
+The library has been tested with Scala 2.10.6 and 2.11.X. If you want to use another
+version, feel free to contact us.
 
 Features
 ================
@@ -32,36 +34,33 @@ Quick example : Scala API
 
 You can link against this library in your program at the following coordinates: TBD.
 
-**Scala 2.11**
+**Scala 2.10.6 and 2.11.X**
 
 .. code:: scala
 
-  // SparkSession
+  // Import SparkSession
   import org.apache.spark.sql.SparkSession
 
   // Import the implicit to allow interaction with FITS
   import com.sparkfits.fits._
 
-  // Initialise your SparkSession
-  val spark = SparkSession
-    .builder()
-    .getOrCreate()
+  object ReadFits extends App {
+    // Initialise your SparkSession
+    val spark = SparkSession
+      .builder()
+      .getOrCreate()
 
-  // Read as a DataFrame the first HDU of a table fits.
-  val df = spark.readfits
-    .option("datatype", "table")            // we support only table for the moment
-    .option("HDU", 1)                       // First HDU
-    .option("printHDUHeader", false)        // to print the HEADER on the screen
-    .load("src/test/resources/test.fits")   // load data as DataFrame
-
-  // To show the schema
-  df.printSchema()
-
-  // To show the 20 top rows
-  df.show()
+    // Read as a DataFrame the first HDU of a table fits.
+    val df = spark.readfits
+      .option("datatype", "table")            // we support only table for the moment
+      .option("HDU", 1)                       // First HDU
+      .option("printHDUHeader", false)        // to print the HEADER on the screen
+      .load("src/test/resources/test.fits")   // load data as DataFrame
+  }
 
 Note that the schema is directly inferred from the HEADER of the hdu.
 In case the HEADER is not present or corrupted, you can also manually specify it (TBD).
+See below for a use with spark-shell.
 
 Using with Spark shell
 ================

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import Dependencies._
 lazy val root = (project in file(".")).
  settings(
    inThisBuild(List(
-     scalaVersion := "2.11.8",
      version      := "0.1.0",
      mainClass in Compile := Some("com.sparkfits.ReadFits")
    )),

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+SBT_VERSION=2.11.8
+SBT_VERSION_SPARK=2.11
+
 # Package it
-sbt assembly
+sbt ++${SBT_VERSION} assembly
 
 # Jars
 FITS=lib/nom-tam-fits-1.15.2.jar
@@ -13,5 +16,5 @@ fitsfn="src/test/resources/test.fits"
 spark-submit \
   --master local[*] \
   --class com.sparkfits.ReadFits \
-  target/scala-2.11/spark-fits-assembly-0.1.0.jar \
+  target/scala-${SBT_VERSION_SPARK}/spark-fits-assembly-0.1.0.jar \
   $fitsfn


### PR DESCRIPTION
Add support for Scala 2.10.6. Travis script updated.
You now need to specify your scala version in the run.sh.