### PR TITLE
Simplify the conversion rdd to DataFrame

### DIFF
--- a/src/main/scala/com/sparkfits/FitsFileInputFormat.scala
+++ b/src/main/scala/com/sparkfits/FitsFileInputFormat.scala
@@ -30,10 +30,10 @@ private[sparkfits] object FitsFileInputFormat {
   /**
     * `FitsFileInputFormat` extends `FileInputFormat` by creating a custom
     * RecordReader for FITS file. Note that the output class type is
-    * KEY: LongWritable, VALUE: List[List[_]]. VALUE will be converted later
+    * KEY: LongWritable, VALUE: IndexedSeq[Row]. VALUE will be converted later
     * into Row to easily create DataFrame.
     */
-  class FitsFileInputFormat extends FileInputFormat[LongWritable, List[List[_]]] {
+  class FitsFileInputFormat extends FileInputFormat[LongWritable, IndexedSeq[Row]] {
 
     /**
       * Override the RecordReader class with our custom RecordReader for FITS file
@@ -44,6 +44,6 @@ private[sparkfits] object FitsFileInputFormat {
       *   The context for task attempts (see Hadoop code source).
       */
     override def createRecordReader(split: InputSplit, context: TaskAttemptContext):
-      RecordReader[LongWritable, List[List[_]]] = new FitsRecordReader()
+      RecordReader[LongWritable, IndexedSeq[Row]] = new FitsRecordReader()
   }
 }

--- a/src/main/scala/com/sparkfits/FitsFileInputFormat.scala
+++ b/src/main/scala/com/sparkfits/FitsFileInputFormat.scala
@@ -30,10 +30,10 @@ private[sparkfits] object FitsFileInputFormat {
   /**
     * `FitsFileInputFormat` extends `FileInputFormat` by creating a custom
     * RecordReader for FITS file. Note that the output class type is
-    * KEY: LongWritable, VALUE: IndexedSeq[Row]. VALUE will be converted later
+    * KEY: LongWritable, VALUE: Seq[Row]. VALUE will be converted later
     * into Row to easily create DataFrame.
     */
-  class FitsFileInputFormat extends FileInputFormat[LongWritable, IndexedSeq[Row]] {
+  class FitsFileInputFormat extends FileInputFormat[LongWritable, Seq[Row]] {
 
     /**
       * Override the RecordReader class with our custom RecordReader for FITS file
@@ -44,6 +44,6 @@ private[sparkfits] object FitsFileInputFormat {
       *   The context for task attempts (see Hadoop code source).
       */
     override def createRecordReader(split: InputSplit, context: TaskAttemptContext):
-      RecordReader[LongWritable, IndexedSeq[Row]] = new FitsRecordReader()
+      RecordReader[LongWritable, Seq[Row]] = new FitsRecordReader()
   }
 }

--- a/src/main/scala/com/sparkfits/FitsRecordReader.scala
+++ b/src/main/scala/com/sparkfits/FitsRecordReader.scala
@@ -53,7 +53,7 @@ import com.sparkfits.FitsLib.FitsBlock
   * type element by element, and finally grouped into rows.
   *
   */
-class FitsRecordReader extends RecordReader[LongWritable, List[List[_]]] {
+class FitsRecordReader extends RecordReader[LongWritable, IndexedSeq[Row]] {
 
   // Initialise mutable variables to be used by the executors
   // Handle the HDFS block boundaries
@@ -76,7 +76,7 @@ class FitsRecordReader extends RecordReader[LongWritable, List[List[_]]] {
 
   // The (key, value) used to create the RDD
   private var recordKey: LongWritable = null
-  private var recordValue: List[List[_]] = null
+  private var recordValue: IndexedSeq[Row] = null
 
   // Intermediate variable to store binary data
   private var recordValueBytes: Array[Byte] = null
@@ -101,10 +101,10 @@ class FitsRecordReader extends RecordReader[LongWritable, List[List[_]]] {
 
   /**
     * Get the current Value.
-    * @return (List[List[_]]) Value is a list of heterogeneous lists. It will
+    * @return (IndexedSeq[Row]) Value is a list of heterogeneous lists. It will
     *   be converted to List[Row] later.
     */
-  override def getCurrentValue: List[List[_]] = {
+  override def getCurrentValue: IndexedSeq[Row] = {
     recordValue
   }
 
@@ -328,43 +328,12 @@ class FitsRecordReader extends RecordReader[LongWritable, List[List[_]]] {
       fB.data.readFully(recordValueBytes, 0, recordLength)
 
       // Convert each row
-
       // 1 task: 32 MB @ 2s
-      val tmp = for {
+      recordValue = for {
         i <- 0 to recordLength / rowSizeLong.toInt - 1
-      } yield (fB.readLineFromBuffer(
+      } yield (Row.fromSeq(fB.readLineFromBuffer(
           recordValueBytes.slice(
-            rowSizeInt*i, rowSizeInt*(i+1))))
-      recordValue = tmp.toList
-
-      // 1 task: 32 MB @ 5s
-      // val tmp = recordValueBytes.grouped(rowSizeLong.toInt)
-      //   .map(x => fB.readLineFromBuffer(x))
-      // recordValue = tmp.toList
-
-      // 1 task: 32 MB @ 1-2s
-      // /!\ Prepend!!! Must reverse the list (TODO)
-      // recordValue = List[List[Any]](fB.readLineFromBuffer(
-      //   recordValueBytes.slice(0, rowSizeLong.toInt)))
-      // for (i <- 1 to recordLength / rowSizeInt - 1) {
-      //   recordValue = fB.readLineFromBuffer(
-      //     recordValueBytes.slice(rowSizeInt*i, rowSizeInt*(i+1))) :: recordValue
-      // }
-
-      // 1 task: 32 MB @ 2s
-      // val recordValue = new Array[List[Any]](recordLength / rowSizeInt)
-      // for (i <- 0 to recordLength / rowSizeInt - 1) {
-      //   recordValue(i) = fB.readLineFromBuffer(recordValueBytes.slice(rowSizeInt*i, rowSizeInt*(i+1)))
-      // }
-      // recordValue = tmp.toList
-
-      // val l1 = mutable.MutableList.empty[List[Any]]
-      // for (i <- 0 to recordLength / rowSizeInt - 1) {
-      //   l1 += fB.readLineFromBuffer(recordValueBytes.slice(rowSizeInt*i, rowSizeInt*(i+1)))
-      // }
-      // recordValue = l1.toList
-
-      // recordValue = tmp.map(x => Row.fromSeq(x)).toList
+            rowSizeInt*i, rowSizeInt*(i+1)))))
 
       // update our current position
       currentPosition = currentPosition + recordLength

--- a/src/main/scala/com/sparkfits/package.scala
+++ b/src/main/scala/com/sparkfits/package.scala
@@ -450,7 +450,7 @@ package object fits {
       val rdd = spark.sparkContext.newAPIHadoopFile(fn,
         classOf[FitsFileInputFormat],
         classOf[LongWritable],
-        classOf[IndexedSeq[Row]],
+        classOf[Seq[Row]],
         conf).flatMap(x => x._2)
 
       // Return DataFrame with Schema

--- a/src/main/scala/com/sparkfits/package.scala
+++ b/src/main/scala/com/sparkfits/package.scala
@@ -447,14 +447,11 @@ package object fits {
       fB.data.close()
 
       // Distribute the table data
-      val rdd = spark.sparkContext.newAPIHadoopFile(
-        fn,
+      val rdd = spark.sparkContext.newAPIHadoopFile(fn,
         classOf[FitsFileInputFormat],
         classOf[LongWritable],
-        classOf[List[List[_]]],
-        conf)
-          .flatMap(x => x._2)
-          .map(x => Row.fromSeq(x))
+        classOf[IndexedSeq[Row]],
+        conf).flatMap(x => x._2)
 
       // Return DataFrame with Schema
       spark.createDataFrame(rdd, schema)

--- a/src/test/scala/com/sparkfits/packageTest.scala
+++ b/src/test/scala/com/sparkfits/packageTest.scala
@@ -221,4 +221,13 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
 
     assert(exception.getMessage.contains("0 files detected"))
   }
+
+  // Test ordering of elements in the DF
+  test("Ordering test: Is the first element of the DF correct?") {
+    val results = spark.readfits
+      .option("datatype", "table")
+      .option("HDU", 1)
+      .load(fn)
+    assert(results.select(col("target")).first.getString(0) == "NGC0000000")
+  }
 }


### PR DESCRIPTION
The conversion into Row is handled at the level of recordreader directly, and we use new Seq Builder.
Small speed up observed (but not significant).