### PR TITLE
Allow the user to specify which columns to load in the DF

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,7 @@ Here is the minimal syntax in Scala 2.10.6 and 2.11.X to play with the package:
     val df = spark.readfits
       .option("datatype", "table")          // [mandatory] We support only table for the moment.
       .option("HDU", <Int>)                 // [mandatory] Which HDU you want to read.
+      .option("columns", <List[String]>)    // [optional]  Names of the columns to load. Default loads all columns.
       .option("recordLength", <Int>)        // [optional]  If you want to define yourself the length of a record.
       .option("verbose", <Boolean>)         // [optional]  If you want to print debugging messages on screen.
       .schema(<StructType>)                 // [optional]  If you want to bypass the header.
@@ -110,6 +111,12 @@ You can also specify a directory containing several FITS files
 (``path="hdfs://<IP>:<PORT>//path_to_dir"``) with the same HDU structure.
 The connector will load the data from the same HDU from all the files in one single
 DataFrame. This is particularly useful to manipulate many small files written the same way as once.
+
+You can specify which columns you want to load in the DataFrame, using the option ``columns``.
+Example, ``.option("columns", List("target", "Index"))`` will load all the data, but
+will decode only these two columns. If not specified, all columns will be loaded in the
+DataFrame (and you can select columns manually later). In a future release, the selection of columns will be
+done at the level of the loading of the data directly (for speed-up).
 
 The ``recordLength`` option controls how the data is split and read inside each HDFS block (or more
 precisely inside each InputSplit as they are not the same) by individual mappers for processing.

--- a/src/main/scala/com/sparkfits/FitsSchema.scala
+++ b/src/main/scala/com/sparkfits/FitsSchema.scala
@@ -79,11 +79,12 @@ object FitsSchema {
     // Grab max number of column
     val colmax = fB.getNCols(header)
 
-    // Get the list of StructField recursively.
-    if (col == colmax)
-      Nil
-    else
-      ReadMyType(fB.getColumnName(header, col), fB.getColumnType(header, col)) :: ListOfStruct(fB, col + 1)
+    // Get the list of StructField.
+    val lStruct = List.newBuilder[StructField]
+    for (col <- fB.colPositions) {
+      lStruct += ReadMyType(fB.getColumnName(header, col), fB.getColumnType(header, col))
+    }
+    lStruct.result
   }
 
   /**

--- a/src/main/scala/com/sparkfits/package.scala
+++ b/src/main/scala/com/sparkfits/package.scala
@@ -191,6 +191,19 @@ package object fits {
     }
 
     /**
+      * Adds an input options for reading the underlying data source.
+      * (key, List[String])
+      *
+      * @param key : (String)
+      *   Name of the option
+      * @param value : (List[String])
+      *   Value of the option.
+      */
+    def option(key: String, value: List[String]): FitsContext = {
+      option(key, value.mkString(","))
+    }
+
+    /**
       * Adds a schema to our data. It will overwrite the inferred schema from
       * the HDU header. Useful if the header is corrupted.
       *

--- a/src/test/scala/com/sparkfits/FitsLibTest.scala
+++ b/src/test/scala/com/sparkfits/FitsLibTest.scala
@@ -221,8 +221,8 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val names = fB1.getHeaderNames(header)
 
     // Check an entry with a name (TTYPE1), and one without.
-    // By default, header line without name gets a default value of "".
-    assert(names("TTYPE1") == "target" && names("NAXIS1") == "")
+    // By default, header line without name are not taken.
+    assert(names("TTYPE1") == "target" && !names.contains("NAXIS1"))
   }
 
   // Check the comment conversion

--- a/src/test/scala/com/sparkfits/ReadFitsTest.scala
+++ b/src/test/scala/com/sparkfits/ReadFitsTest.scala
@@ -122,6 +122,16 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
     assert(results.select("Index").count() == 20000)
   }
 
+  // Test if one accesses column as expected for HDU 1
+  test("Column test: Can you select only some columns?") {
+    val results = spark.readfits
+      .option("datatype", "table")
+      .option("HDU", 1)
+      .option("columns", "target")
+      .load(fn)
+    assert(results.first.size == 1)
+  }
+
   // Test if type cast is done correctly
   test("Type test: Do you see a Boolean?") {
     val results = spark.readfits


### PR DESCRIPTION
You can specify which columns you want to load in the DataFrame, using the option `columns`. Example, `.option("columns", List("target", "Index"))` will load all the data, but will decode only these two columns. If not specified, all columns will be loaded in the DataFrame (and you can select columns manually later). In a future release, the selection of columns will be done at the level of the loading of the data directly (for speed-up).