### PR TITLE
Prepare the ground for handling different HDU types.

### DIFF
--- a/src/main/scala/com/sparkfits/FitsLib.scala
+++ b/src/main/scala/com/sparkfits/FitsLib.scala
@@ -109,7 +109,7 @@ object FitsLib {
     val selectedColNames = if (conf.get("columns") != null) {
       conf.getStrings("columns").deep.toList.asInstanceOf[List[String]]
     } else {
-      colNames.filter(x=>x._1.contains("TTYPE")).values.toList.asInstanceOf[List[String]]
+      colNames.filter(x=>x._1.contains("TYPE")).values.toList.asInstanceOf[List[String]]
     }
     val colPositions = selectedColNames.map(
       x=>getColumnPos(blockHeader, x)).toList.sorted
@@ -136,18 +136,18 @@ object FitsLib {
       val colNames = getHeaderNames(blockHeader)
 
       // Check if the HDU is empty, a table or an image
-      val isEmpty = empty_hdu
       val isTable = colNames.filter(
         x=>x._2.contains("BINTABLE")).values.toList.size > 0
       val isImage = colNames.filter(
         x=>x._2.contains("IMAGE")).values.toList.size > 0
+      val isEmpty = empty_hdu
 
-      val fitstype = if (isEmpty) {
-        "EMPTY"
-      } else if (isTable) {
+      val fitstype = if (isTable) {
         "BINTABLE"
       } else if (isImage) {
         "IMAGE"
+      } else if (isEmpty) {
+        "EMPTY"
       } else {
         "NOT UNDERSTOOD"
       }

--- a/src/main/scala/com/sparkfits/FitsLib.scala
+++ b/src/main/scala/com/sparkfits/FitsLib.scala
@@ -97,6 +97,18 @@ object FitsLib {
     } else readHeader
     resetCursorAtHeader
 
+    // Check that we have a bintable (to be changed later on when
+    // images will be ready)
+    val colNames = getHeaderNames(blockHeader)
+    val isTable = colNames.filter(x=>x._2.contains("BINTABLE")).values.toList.size > 0 || empty_hdu
+    isTable match {
+      case true => isTable
+      case false => throw new AssertionError("""
+        Currently only reading data from bintable is supported.
+        Support for image data will be added later.
+        """)
+    }
+
     // Get informations on element types and number of columns.
     val rowTypes = if (empty_hdu) {
       List[String]()
@@ -104,7 +116,7 @@ object FitsLib {
     val ncols = rowTypes.size
 
     // Check if the user specifies columns to select
-    val colNames = getHeaderNames(blockHeader)
+    // val colNames = getHeaderNames(blockHeader)
 
     val selectedColNames = if (conf.get("columns") != null) {
       conf.getStrings("columns").deep.toList.asInstanceOf[List[String]]

--- a/src/main/scala/com/sparkfits/FitsSchema.scala
+++ b/src/main/scala/com/sparkfits/FitsSchema.scala
@@ -102,6 +102,17 @@ object FitsSchema {
   }
 
   /**
+    * Return schema for empty DataFrame
+    *
+    * @return Return a `StructType` with one entry stating nothing.
+    *
+    */
+  def getEmptySchema : StructType = {
+    // Construct empty schema
+    StructType(StructField("empty", StringType, true) :: Nil)
+  }
+
+  /**
     * A few checks on the header for bintable.
     * Careful, it will throw errors for image!
     *

--- a/src/main/scala/com/sparkfits/ReadFits.scala
+++ b/src/main/scala/com/sparkfits/ReadFits.scala
@@ -37,7 +37,6 @@ object ReadFits {
     // Loop over the two HDU of the test file
     for (hdu <- 1 to 2) {
       val df = spark.readfits
-        .option("datatype", "table")        // Binary table
         .option("HDU", hdu)                 // Index of the HDU
         .option("verbose", true)            // pretty print
         .option("recordLength", 1 * 1024)   // 1 KB per record

--- a/src/main/scala/com/sparkfits/package.scala
+++ b/src/main/scala/com/sparkfits/package.scala
@@ -307,33 +307,33 @@ package object fits {
       verbosity = Try{extraOptions("verbose")}.getOrElse("false").toBoolean
 
       // Check that you can read the data!
-      val dataType = Try {
-        extraOptions("datatype")
-      }
-      dataType match {
-        case Success(value) => extraOptions("datatype")
-        case Failure(e : NullPointerException) =>
-          throw new NullPointerException(e.getMessage)
-        case Failure(e : NoSuchElementException) =>
-          throw new NoSuchElementException("""
-          You did not specify the data type!
-          Please choose one of the following:
-            spark.readfits.option("datatype", "table")
-            spark.readfits.option("datatype", "image")
-            """)
-        case Failure(_) => println("Unknown Exception")
-      }
+      // val dataType = Try {
+      //   extraOptions("datatype")
+      // }
+      // dataType match {
+      //   case Success(value) => extraOptions("datatype")
+      //   case Failure(e : NullPointerException) =>
+      //     throw new NullPointerException(e.getMessage)
+      //   case Failure(e : NoSuchElementException) =>
+      //     throw new NoSuchElementException("""
+      //     You did not specify the data type!
+      //     Please choose one of the following:
+      //       spark.readfits.option("datatype", "table")
+      //       spark.readfits.option("datatype", "image")
+      //       """)
+      //   case Failure(_) => println("Unknown Exception")
+      // }
 
       // Check that the user specifies table
-      val dataTypeTable = extraOptions("datatype").contains("table")
-      dataTypeTable match {
-        case true => extraOptions("datatype")
-        case false => throw new AssertionError("""
-          Currently only reading data from table is supported.
-          Support for image data will be added later.
-          Please use spark.readfits.option("datatype", "table")
-          """)
-      }
+      // val dataTypeTable = extraOptions("datatype").contains("table")
+      // dataTypeTable match {
+      //   case true => extraOptions("datatype")
+      //   case false => throw new AssertionError("""
+      //     Currently only reading data from table is supported.
+      //     Support for image data will be added later.
+      //     Please use spark.readfits.option("datatype", "table")
+      //     """)
+      // }
 
       // Check that the user specifies table
       val isIndexHDU = Try {

--- a/src/test/scala/com/sparkfits/ReadFitsTest.scala
+++ b/src/test/scala/com/sparkfits/ReadFitsTest.scala
@@ -63,7 +63,7 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   test("HDU test: Is there a HDU number?") {
     val results = spark.readfits
     val exception = intercept[NoSuchElementException] {
-      results.option("datatype", "table").load(fn)
+      results.load(fn)
     }
     assert(exception.getMessage.contains("HDU"))
   }
@@ -72,21 +72,27 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   test("HDU test: Is HDU index above the max HDU index?") {
     val results = spark.readfits
     val exception = intercept[AssertionError] {
-      results.option("datatype", "table").option("HDU", 30).load(fn)
+      results.option("HDU", 30).load(fn)
     }
     assert(exception.getMessage.contains("HDU"))
   }
 
   // Test if the user provides the data type in the HDU
-  test("Table test: can you return an empty DataFrame if it's not a table?") {
+  test("HDU type test: Return an empty DataFrame if HDU is empty?") {
     val results = spark.readfits.option("HDU", 0).load(fn)
+    assert(results.count() == 0)
+  }
+
+  // Test if the user provides the data type in the HDU
+  test("HDU type test: Return an empty DataFrame if HDU is an image?") {
+    val fn_image = "src/test/resources/toTest/tst0009.fits"
+    val results = spark.readfits.option("HDU", 2).load(fn_image)
     assert(results.count() == 0)
   }
 
   // Test if one accesses column as expected for HDU 1
   test("Count test: Do you count all elements in a column in HDU 1?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     assert(results.select("RA").count() == 20000)
@@ -95,7 +101,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Test if one accesses column as expected for HDU 1
   test("Count test: Do you count all elements in a column in HDU 2?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 2)
       .load(fn)
     assert(results.select("Index").count() == 20000)
@@ -104,7 +109,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Test if one accesses column as expected for HDU 1
   test("Column test: Can you select only some columns?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .option("columns", "target")
       .load(fn)
@@ -114,7 +118,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Test if type cast is done correctly
   test("Type test: Do you see a Boolean?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 2)
       .load(fn)
     // Elements of a column are arrays of 1 element
@@ -124,7 +127,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Test if type cast is done correctly
   test("Type test: Do you see a Long?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     // Elements of a column are arrays of 1 element
@@ -134,7 +136,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Test if type cast is done correctly
   test("Type test: Do you see a Int?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     // Elements of a column are arrays of 1 element
@@ -144,7 +145,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Test if type cast is done correctly
   test("Type test: Do you see a Float?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     // Elements of a column are arrays of 1 element
@@ -154,7 +154,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Test if type cast is done correctly
   test("Type test: Do you see a Double?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     // Elements of a column are arrays of 1 element
@@ -164,7 +163,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Test if type cast is done correctly
   test("Type test: Do you see a String?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     // Elements of a column are arrays of 1 element

--- a/src/test/scala/com/sparkfits/ReadFitsTest.scala
+++ b/src/test/scala/com/sparkfits/ReadFitsTest.scala
@@ -59,23 +59,23 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Add more and put a loop for several tests!
   val fn = "src/test/resources/test_file.fits"
 
-  // Test if the user provides the data type in the HDU
-  test("dataType test: is there table or image in options?") {
-    val results = spark.readfits
-    val exception = intercept[NoSuchElementException] {
-      results.load(fn)
-    }
-    assert(exception.getMessage.contains("datatype"))
-  }
-
-  // Test if the data type is table (image not yet supported)
-  test("dataType test: Is the datatype a table?") {
-    val results = spark.readfits
-    val exception = intercept[AssertionError] {
-      results.option("datatype", "image").load(fn)
-    }
-    assert(exception.getMessage.contains("datatype"))
-  }
+  // // Test if the user provides the data type in the HDU
+  // test("dataType test: is there table or image in options?") {
+  //   val results = spark.readfits
+  //   val exception = intercept[NoSuchElementException] {
+  //     results.load(fn)
+  //   }
+  //   assert(exception.getMessage.contains("datatype"))
+  // }
+  //
+  // // Test if the data type is table (image not yet supported)
+  // test("dataType test: Is the datatype a table?") {
+  //   val results = spark.readfits
+  //   val exception = intercept[AssertionError] {
+  //     results.option("datatype", "image").load(fn)
+  //   }
+  //   assert(exception.getMessage.contains("datatype"))
+  // }
 
   // Test if the user provides the HDU index to be read
   test("HDU test: Is there a HDU number?") {

--- a/src/test/scala/com/sparkfits/ReadFitsTest.scala
+++ b/src/test/scala/com/sparkfits/ReadFitsTest.scala
@@ -59,24 +59,6 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   // Add more and put a loop for several tests!
   val fn = "src/test/resources/test_file.fits"
 
-  // // Test if the user provides the data type in the HDU
-  // test("dataType test: is there table or image in options?") {
-  //   val results = spark.readfits
-  //   val exception = intercept[NoSuchElementException] {
-  //     results.load(fn)
-  //   }
-  //   assert(exception.getMessage.contains("datatype"))
-  // }
-  //
-  // // Test if the data type is table (image not yet supported)
-  // test("dataType test: Is the datatype a table?") {
-  //   val results = spark.readfits
-  //   val exception = intercept[AssertionError] {
-  //     results.option("datatype", "image").load(fn)
-  //   }
-  //   assert(exception.getMessage.contains("datatype"))
-  // }
-
   // Test if the user provides the HDU index to be read
   test("HDU test: Is there a HDU number?") {
     val results = spark.readfits
@@ -96,12 +78,9 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   }
 
   // Test if the user provides the data type in the HDU
-  test("Table test: Are you really accessing a Table?") {
-    val results = spark.readfits
-    val exception = intercept[AssertionError] {
-      results.option("datatype", "table").option("HDU", 0).load(fn)
-    }
-    assert(exception.getMessage.contains("BINTABLE"))
+  test("Table test: can you return an empty DataFrame if it's not a table?") {
+    val results = spark.readfits.option("HDU", 0).load(fn)
+    assert(results.count() == 0)
   }
 
   // Test if one accesses column as expected for HDU 1

--- a/src/test/scala/com/sparkfits/packageTest.scala
+++ b/src/test/scala/com/sparkfits/packageTest.scala
@@ -101,7 +101,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
   // Test DataFrame
   test("DataFrame test: can you really make a DF from the hdu?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     assert(results.isInstanceOf[DataFrame])
@@ -121,7 +120,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
     )
 
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .schema(schema)
       .load(fn)
@@ -137,7 +135,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
   // Test Data distribution
   test("Data distribution test: Can you count all elements?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     assert(results.select(col("Index")).count().toInt == 20000)
@@ -145,7 +142,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
 
   test("Data distribution test: Can you sum up all elements?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     assert(
@@ -157,7 +153,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
 
   test("Data distribution test: Do you pass over all blocks?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .option("recordLength", 16 * 1024)
       .load(fn)
@@ -170,7 +165,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
 
   test("Header printing test") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .option("verbose", true)
       .option("recordLength", 16 * 1024)
@@ -184,7 +178,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
   test("Multi files test: Can you read several FITS file?") {
     val fn = "src/test/resources/dir"
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .option("verbose", true)
       .option("recordLength", 16 * 1024)
@@ -195,7 +188,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
   test("Multi files test: Can you detect an error in reading different FITS file?") {
     val fn = "src/test/resources/dirNotOk"
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .option("verbose", true)
       .option("recordLength", 16 * 1024)
@@ -210,7 +202,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
   test("No file test: Can you detect an error if there is no input FITS file found?") {
     val fn = "src/test/resources/dirfjsdhf"
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .option("verbose", true)
       .option("recordLength", 16 * 1024)
@@ -225,7 +216,6 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
   // Test ordering of elements in the DF
   test("Ordering test: Is the first element of the DF correct?") {
     val results = spark.readfits
-      .option("datatype", "table")
       .option("HDU", 1)
       .load(fn)
     assert(results.select(col("target")).first.getString(0) == "NGC0000000")


### PR DESCRIPTION
Bintables are still the only to be handled, but the structure is now more flexible to include new types (like images).