### PR TITLE
Generalize reader for headers

### DIFF
--- a/src/test/scala/com/sparkfits/FitsLibTest.scala
+++ b/src/test/scala/com/sparkfits/FitsLibTest.scala
@@ -207,7 +207,7 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
 
     // Check an entry with a value (BITPIX), and one without.
     // By default, header line without value gets a default value of 0.
-    assert(values("BITPIX") == 8 && values("TTYPE1") == 0)
+    assert(values("BITPIX").toInt == 8)
   }
 
   // Check the name conversion
@@ -235,10 +235,8 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     // Grab the names as map(keywords/names)
     val comments = fB1.getHeaderComments(header)
 
-    // Check an entry with a comment (XTENSION), and one without.
-    // By default, header line without comment gets a default value of "".
-    assert(comments("XTENSION") == "binary table extension" &&
-      comments("TTYPE1") == "")
+    // Check an entry with a comment (XTENSION).
+    assert(comments("XTENSION") == "binary table extension")
   }
 
   // Check the reader for the number of rows


### PR DESCRIPTION
Several things:
* Reorganise the way we extract information from the header. In FitsLib, methods like ``getHeaderValues``, ``getHeaderNames`` and ``getHeaderComments`` have been generalized.
* ``getHeaderValues`` returns ``Map[String, String]``, so value conversion has to be done later.
* I added the getDataLen method written by @ChristianArnault .
* If user tries to read a HDU which is neither a BINTABLE or empty, the code throws a ``AssertionError``.

Next step for images: split FitsBlock into several classes - one per HDU type, and isolate common methods in the object.