### PR TITLE
Large reformatting:

### DIFF
--- a/run_python_cluster.sh
+++ b/run_python_cluster.sh
@@ -25,13 +25,20 @@ sbt ++${SBT_VERSION} package
 
 # Parameters (put your file)
 fitsfn="hdfs://134.158.75.222:8020//user/julien.peloton/cat2149.fits"
+fitsfn="hdfs://134.158.75.222:8020//lsst/images/a.fits"
+
+master="--master spark://134.158.75.222:7077"
+memory="--driver-memory 4g --executor-memory 18g"
+conf="--conf spark.kryoserializer.buffer.max=1g"
+jars="--jars target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar"
+pgm="src/main/python/ReadImage.py"
+imput="-inputpath $fitsfn"
 
 # Run it!
-spark-submit \
-  --master spark://134.158.75.222:7077 \
-  --driver-memory 4g --executor-memory 18g \
-  --jars target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar \
-  examples/python/readfits.py \
-  -inputpath $fitsfn
+cmd="spark-submit ${master} ${memory} ${conf} ${jars} ${pgm} ${input}"
+
+echo $cmd
+
+#   examples/python/readfits.py
 
 # --executor-cores 17 --total-executor-cores 102 \

--- a/run_scala_cluster.sh
+++ b/run_scala_cluster.sh
@@ -24,7 +24,13 @@ VERSION=0.2.0
 sbt ++${SBT_VERSION} package
 
 # Parameters (put your file)
-fitsfn="hdfs://134.158.75.222:8020//user/julien.peloton/cat2149.fits"
+#fitsfn="file:/home/christian.arnault/spark-fits/b.fits"
+#fitsfn="file:/home/christian.arnault/spark-fits/a.fits"
+fitsfn="hdfs://134.158.75.222:8020//lsst/images/a.fits"
+#fitsfn="file:/home/christian.arnault/spark-fits/src/test/resources/toTest/tst0001.fits"
+#fitsfn="file:/home/christian.arnault/spark-fits/src/test/resources/test_file.fits"
+#fitsfn="hdfs://134.158.75.222:8020//user/julien.peloton/cat2149.fits"
+
 
 # Run it!
 spark-submit \

--- a/run_scala_cluster_image.sh
+++ b/run_scala_cluster_image.sh
@@ -24,15 +24,12 @@ VERSION=0.2.0
 sbt ++${SBT_VERSION} package
 
 # Parameters (put your file)
-#fitsfn="hdfs://134.158.75.222:8020//lsst/images/a.fits"
-#fitsfn="file:/home/christian.arnault/spark-fits/src/test/resources/toTest/tst0001.fits"
-#fitsfn="file:/home/christian.arnault/spark-fits/src/test/resources/test_file.fits"
-fitsfn="hdfs://134.158.75.222:8020//lsst/tests/toTest/tst0009.fits"
-#fitsfn="hdfs://134.158.75.222:8020//user/julien.peloton/cat2149.fits"
+fitsfn="hdfs://134.158.75.222:8020//lsst/tests/tst0009.fits"
+fitsfn="hdfs://134.158.75.222:8020//lsst/images/a.fits"
 
 
 # Run it!
-cmd="spark-submit --master spark://134.158.75.222:7077 --driver-memory 4g --executor-memory 18g --class com.sparkfits.ReadFits target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar $fitsfn"
+cmd="spark-submit --master spark://134.158.75.222:7077 --driver-memory 4g --executor-memory 18g --class com.sparkfits.ReadImage target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar $fitsfn"
 
 $cmd
 

--- a/src/main/scala/com/sparkfits/FitsBintable.scala
+++ b/src/main/scala/com/sparkfits/FitsBintable.scala
@@ -1,0 +1,198 @@
+package com.sparkfits
+
+import java.io.IOError
+import java.nio.ByteBuffer
+import java.io.EOFException
+import java.nio.charset.StandardCharsets
+
+import org.apache.spark.sql.types._
+
+/**
+  * This is the beginning of a FITS library in Scala.
+  * You will find a large number of methodes to manipulate Binary Table HDUs.
+  * There is no support for image HDU for the moment.
+  */
+object FitsBintableLib {
+  case class BintableInfos() extends FitsLib.Infos {
+
+    var rowTypes: List[String] = List()
+    var colNames: Map[String, String] = Map()
+    var selectedColNames: List[String] = List()
+    var colPositions: List[Int] = List()
+    var splitLocations: List[Int] = List()
+
+    def initialize(_rowTypes: List[String],
+                   _colNames: Map[String, String],
+                   _selectedColNames: List[String],
+                   _colPositions: List[Int],
+                   _splitLocations: List[Int]) = {
+      rowTypes = _rowTypes
+      this.colNames = _colNames
+      this.selectedColNames = _selectedColNames
+      this.colPositions = _colPositions
+      this.splitLocations = _splitLocations
+    }
+    /**
+      * Companion to readLineFromBuffer. Convert one array of bytes
+      * corresponding to one element of the table into its primitive type.
+      *
+      * @param subbuf : (Array[Byte])
+      *   Array of byte describing one element of the table.
+      * @param fitstype : (String)
+      *   The type of this table element according to the header.
+      * @return the table element converted from binary.
+      *
+      */
+
+    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {
+      val shortType = FitsLib.shortStringValue{fitstype}
+
+      shortType match {
+        // 16-bit Integer
+        case x if shortType.contains("I") => {
+          ByteBuffer.wrap(subbuf, 0, 2).getShort()
+        }
+        // 32-bit Integer
+        case x if shortType.contains("J") => {
+          ByteBuffer.wrap(subbuf, 0, 4).getInt()
+        }
+        // 64-bit Integer
+        case x if shortType.contains("K") => {
+          ByteBuffer.wrap(subbuf, 0, 8).getLong()
+        }
+        // Single precision floating-point
+        case x if shortType.contains("E") => {
+          ByteBuffer.wrap(subbuf, 0, 4).getFloat()
+        }
+        // Double precision floating-point
+        case x if shortType.contains("D") => {
+          ByteBuffer.wrap(subbuf, 0, 8).getDouble()
+        }
+        // Boolean
+        case x if shortType.contains("L") => {
+          // 1 Byte containing the ASCII char T(rue) or F(alse).
+          subbuf(0).toChar == 'T'
+        }
+        // Chain of characters
+        case x if shortType.endsWith("A") => {
+          // Example 20A means string on 20 bytes
+          new String(subbuf, StandardCharsets.UTF_8).trim()
+        }
+        case _ => {
+          println(s"""FitsLib.getElementFromBuffer> Cannot infer size of type $shortType from the header!
+              See getElementFromBuffer
+              """)
+          0
+        }
+      }
+    }
+
+    def getRow(buf: Array[Byte]): List[Any] = {
+      var row = List.newBuilder[Any]
+
+      for (col <- colPositions) {
+        row += getElementFromBuffer(
+          buf.slice(splitLocations(col), splitLocations(col+1)), rowTypes(col))
+      }
+      row.result
+    }
+
+    /**
+      * Get the number of row of a HDU.
+      * We rely on what's written in the header, meaning
+      * here we do not access the data directly.
+      *
+      * @param header : (Array[String])
+      *   The header of the HDU.
+      * @return (Long), the number of rows as written in KEYWORD=NAXIS2.
+      *
+      */
+    def getNRows(header : Array[String]) : Long = {
+      val keyValues = FitsLib.parseHeader(header)
+      keyValues("NAXIS2").toLong
+    }
+
+    /**
+      * Get the number of column of a HDU.
+      * We rely on what's written in the header, meaning
+      * here we do not access the data directly.
+      *
+      * @param header : (Array[String])
+      *   The header of the HDU.
+      * @return (Long), the number of rows as written in KEYWORD=TFIELDS.
+      *
+      */
+    def getNCols(header : Array[String]) : Long = {
+      val keyValues = FitsLib.parseHeader(header)
+      // println(s"getNCols> keyValues=${keyValues.toString}")
+      if (keyValues.contains("TFIELDS")) keyValues("TFIELDS").toLong
+      else 0L
+    }
+
+    /**
+      * Return the types of elements for each column as a list.
+      *
+      * @param col : (Int)
+      *   Column index used for the recursion.
+      * @return (List[String]), list with the types of elements for each column
+      *   as given by the header.
+      *
+      */
+    def getColTypes(header : Array[String]): List[String] = {
+      // Get the names of the Columns
+      val keyValues = FitsLib.parseHeader(header)
+
+      val colTypes = List.newBuilder[String]
+
+      val ncols = getNCols(header).toInt
+
+      for (col <- 0 to ncols-1) {
+        colTypes += FitsLib.shortStringValue(keyValues("TFORM" + (col + 1).toString))
+      }
+      colTypes.result
+    }
+
+    def readMyType(name : String, fitstype : String, isNullable : Boolean = true): StructField = {
+      fitstype match {
+        case x if fitstype.contains("I") => StructField(name, ShortType, isNullable)
+        case x if fitstype.contains("J") => StructField(name, IntegerType, isNullable)
+        case x if fitstype.contains("K") => StructField(name, LongType, isNullable)
+        case x if fitstype.contains("E") => StructField(name, FloatType, isNullable)
+        case x if fitstype.contains("D") => StructField(name, DoubleType, isNullable)
+        case x if fitstype.contains("L") => StructField(name, BooleanType, isNullable)
+        case x if fitstype.contains("A") => StructField(name, StringType, isNullable)
+        case _ => {
+          println(s"""FitsBintable.readMyType> Cannot infer type $fitstype from the header!
+            See com.sparkfits.FitsSchema.scala
+            """)
+          StructField(name, StringType, isNullable)
+        }
+      }
+    }
+
+    def listOfStruct : List[StructField] = {
+      // Grab max number of column
+      // Get the list of StructField.
+      val lStruct = List.newBuilder[StructField]
+
+      val cns = List.newBuilder[String]
+      for (colIndex <- colPositions) {
+        cns += colNames("TTYPE" + (colIndex + 1).toString)
+      }
+
+      // println(s"BintableInfos.listOfStruct> rowTypes=${rowTypes.toString} colPositions=${colPositions.toString} cns=${cns.toString}")
+
+      for (colIndex <- colPositions) {
+        val colName = FitsLib.shortStringValue(colNames("TTYPE" + (colIndex + 1).toString))
+
+        // println(s"listOfStruct> colname=${colName} rowType=${rowTypes(colIndex)}")
+
+        lStruct += readMyType(colName, rowTypes(colIndex))
+      }
+
+      lStruct.result
+
+    }
+
+  }
+}

--- a/src/main/scala/com/sparkfits/FitsBintable.scala
+++ b/src/main/scala/com/sparkfits/FitsBintable.scala
@@ -1,11 +1,10 @@
 package com.sparkfits
 
-import java.io.IOError
+import scala.util.{Try, Success, Failure}
 import java.nio.ByteBuffer
-import java.io.EOFException
 import java.nio.charset.StandardCharsets
-
 import org.apache.spark.sql.types._
+
 
 /**
   * This is the beginning of a FITS library in Scala.
@@ -15,23 +14,105 @@ import org.apache.spark.sql.types._
 object FitsBintableLib {
   case class BintableInfos() extends FitsLib.Infos {
 
-    var rowTypes: List[String] = List()
-    var colNames: Map[String, String] = Map()
-    var selectedColNames: List[String] = List()
-    var colPositions: List[Int] = List()
-    var splitLocations: List[Int] = List()
+    def implemented: Boolean = {true}
 
-    def initialize(_rowTypes: List[String],
-                   _colNames: Map[String, String],
-                   _selectedColNames: List[String],
-                   _colPositions: List[Int],
-                   _splitLocations: List[Int]) = {
-      rowTypes = _rowTypes
-      this.colNames = _colNames
-      this.selectedColNames = _selectedColNames
-      this.colPositions = _colPositions
-      this.splitLocations = _splitLocations
+    /**
+      * Get the number of row of a HDU.
+      * We rely on what's written in the header, meaning
+      * here we do not access the data directly.
+      *
+      * @param header : (Array[String])
+      *   The header of the HDU.
+      * @return (Long), the number of rows as written in KEYWORD=NAXIS2.
+      *
+      */
+    def getNRows(keyValues : Map[String, String]) : Long = {
+      keyValues("NAXIS2").toLong
     }
+
+    /**
+      * Get the size (bytes) of each row of a HDU.
+      * We rely on what's written in the header, meaning
+      * here we do not access the data directly.
+      *
+      * @param header : (Array[String])
+      *   The header of the HDU.
+      * @return (Int), the size (bytes) of one row as written in KEYWORD=NAXIS1.
+      *
+      */
+    def getSizeRowBytes(keyValues: Map[String, String]) : Int = {
+      keyValues("NAXIS1").toInt
+    }
+
+    /**
+      * Get the number of column of a HDU.
+      * We rely on what's written in the header, meaning
+      * here we do not access the data directly.
+      *
+      * @param header : (Array[String])
+      *   The header of the HDU.
+      * @return (Long), the number of rows as written in KEYWORD=TFIELDS.
+      *
+      */
+    def getNCols(keyValues : Map[String, String]) : Long = {
+      // println(s"getNCols> keyValues=${keyValues.toString}")
+      if (keyValues.contains("TFIELDS")) keyValues("TFIELDS").toLong
+      else 0L
+    }
+
+    /**
+      * Return the types of elements for each column as a list.
+      *
+      * @param col : (Int)
+      *   Column index used for the recursion.
+      * @return (List[String]), list with the types of elements for each column
+      *   as given by the header.
+      *
+      */
+    def getColTypes(keyValues: Map[String, String]): List[String] = {
+      val colTypes = List.newBuilder[String]
+
+      val ncols = getNCols(keyValues).toInt
+
+      for (col <- 0 to ncols-1) {
+        colTypes += getColumnType(keyValues, col)
+      }
+      colTypes.result
+    }
+
+    def listOfStruct : List[StructField] = {
+      // Grab max number of column
+      // Get the list of StructField.
+      val lStruct = List.newBuilder[StructField]
+
+      val cns = List.newBuilder[String]
+      for (colIndex <- colPositions) {
+        cns += colNames("TTYPE" + (colIndex + 1).toString)
+      }
+
+      // println(s"BintableInfos.listOfStruct> rowTypes=${rowTypes.toString} colPositions=${colPositions.toString} cns=${cns.toString}")
+
+      for (colIndex <- colPositions) {
+        val colName = FitsLib.shortStringValue(colNames("TTYPE" + (colIndex + 1).toString))
+
+        // println(s"listOfStruct> colname=${colName} rowType=${rowTypes(colIndex)}")
+
+        lStruct += readMyType(colName, rowTypes(colIndex))
+      }
+
+      lStruct.result
+    }
+
+    def getRow(buf: Array[Byte]): List[Any] = {
+      var row = List.newBuilder[Any]
+
+      for (col <- colPositions) {
+        row += getElementFromBuffer(
+          buf.slice(splitLocations(col), splitLocations(col+1)), rowTypes(col))
+      }
+      row.result
+    }
+
     /**
       * Companion to readLineFromBuffer. Convert one array of bytes
       * corresponding to one element of the table into its primitive type.
@@ -43,7 +124,6 @@ object FitsBintableLib {
       * @return the table element converted from binary.
       *
       */
-
     def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {
       val shortType = FitsLib.shortStringValue{fitstype}
 
@@ -87,69 +167,151 @@ object FitsBintableLib {
       }
     }
 
-    def getRow(buf: Array[Byte]): List[Any] = {
-      var row = List.newBuilder[Any]
-
-      for (col <- colPositions) {
-        row += getElementFromBuffer(
-          buf.slice(splitLocations(col), splitLocations(col+1)), rowTypes(col))
-      }
-      row.result
-    }
+    var rowTypes: List[String] = List()
+    var colNames: Map[String, String] = Map()
+    var selectedColNames: List[String] = List()
+    var colPositions: List[Int] = List()
+    var splitLocations: List[Int] = List()
 
     /**
-      * Get the number of row of a HDU.
-      * We rely on what's written in the header, meaning
-      * here we do not access the data directly.
-      *
-      * @param header : (Array[String])
-      *   The header of the HDU.
-      * @return (Long), the number of rows as written in KEYWORD=NAXIS2.
-      *
-      */
-    def getNRows(header : Array[String]) : Long = {
-      val keyValues = FitsLib.parseHeader(header)
-      keyValues("NAXIS2").toLong
-    }
-
-    /**
-      * Get the number of column of a HDU.
-      * We rely on what's written in the header, meaning
-      * here we do not access the data directly.
-      *
-      * @param header : (Array[String])
-      *   The header of the HDU.
-      * @return (Long), the number of rows as written in KEYWORD=TFIELDS.
-      *
-      */
-    def getNCols(header : Array[String]) : Long = {
-      val keyValues = FitsLib.parseHeader(header)
-      // println(s"getNCols> keyValues=${keyValues.toString}")
-      if (keyValues.contains("TFIELDS")) keyValues("TFIELDS").toLong
-      else 0L
-    }
-
-    /**
-      * Return the types of elements for each column as a list.
+      * Description of a row in terms of bytes indices.
+      * rowSplitLocations returns an array containing the position of elements
+      * (byte index) in a row. Example if we have a row with [20A, E, E], one
+      * will have rowSplitLocations -> [0, 20, 24, 28] that is a string
+      * on 20 Bytes, followed by 2 floats on 4 bytes each.
       *
       * @param col : (Int)
-      *   Column index used for the recursion.
-      * @return (List[String]), list with the types of elements for each column
-      *   as given by the header.
+      *   Column position used for the recursion. Should be left at 0.
+      * @return (List[Int]), the position of elements (byte index) in a row.
       *
       */
-    def getColTypes(header : Array[String]): List[String] = {
-      // Get the names of the Columns
+    def rowSplitLocations(rowTypes: List[String], col : Int = 0) : List[Int] = {
+      val ncols = rowTypes.size
+
+      if (col == ncols) {
+        Nil
+      } else {
+        getSplitLocation(rowTypes(col)) :: rowSplitLocations(rowTypes, col + 1)
+      }
+    }
+
+    /**
+      * Companion routine to rowSplitLocations. Returns the size of a primitive
+      * according to its type from the FITS header.
+      *
+      * @param fitstype : (String)
+      *   Element type according to FITS standards (I, J, K, E, D, L, A, etc)
+      * @return (Int), the size (bytes) of the element.
+      *
+      */
+    def getSplitLocation(fitstype : String) : Int = {
+      val shortType = FitsLib.shortStringValue(fitstype)
+
+      shortType match {
+        case x if shortType.contains("I") => 2
+        case x if shortType.contains("J") => 4
+        case x if shortType.contains("K") => 8
+        case x if shortType.contains("E") => 4
+        case x if shortType.contains("D") => 8
+        case x if shortType.contains("L") => 1
+        case x if shortType.endsWith("A") => {
+          // Example 20A means string on 20 bytes
+          x.slice(0, x.length - 1).toInt
+        }
+        case _ => {
+          println(s"""FitsLib.getSplitLocation> Cannot infer size of type $shortType from the header!
+              See com.sparkfits.FitsLib.getSplitLocation
+              """)
+          0
+        }
+      }
+    }
+
+    /**
+      * Get the position (zero based) of a column with name `colName` of a HDU.
+      *
+      * @param header : (Array[String])
+      *   The header of the HDU.
+      * @param colName : (String)
+      *   The name of the column
+      * @return (Int), position (zero-based) of the column.
+      *
+      */
+    def getColumnPos(keyValues : Map[String, String], colName : String) : Int = {
+      // Get the position of the column. Header names are TTYPE#
+      val pos = Try {
+        keyValues.
+          filter(x => x._1.contains("TTYPE")).
+          map(x => (x._1, x._2.split("'")(1).trim())).
+          filter(x => x._2.toLowerCase == colName.toLowerCase).
+          keys.head.substring(5).toInt
+      }.getOrElse(-1)
+
+      val isCol = pos >= 0
+      isCol match {
+        case true => isCol
+        case false => throw new AssertionError(s"""
+          $colName is not a valid column name!
+          """)
+      }
+
+      // Zero based
+      pos - 1
+    }
+
+    /**
+      * Get the type of the elements of a column with index `colIndex` of a HDU.
+      *
+      * @param header : (Array[String])
+      *   The header of the HDU.
+      * @param colIndex : (Int)
+      *   Index (zero-based) of a column.
+      * @return (String), the type (FITS convention) of the elements of the column.
+      *
+      */
+    def getColumnType(keyValues : Map[String, String], colIndex : Int) : String = {
+      // Zero-based index
+      FitsLib.shortStringValue(keyValues("TFORM" + (colIndex + 1).toString))
+    }
+
+    def initialize(empty_hdu: Boolean, header : Array[String], selectedColumns: List[String] = null) = {
+
       val keyValues = FitsLib.parseHeader(header)
 
-      val colTypes = List.newBuilder[String]
+      // Check if the user specifies columns to select
+      this.colNames = keyValues.
+        filter(x => x._1.contains("TTYPE")).
+        map(x => (x._1, x._2.split("'")(1).trim()))
 
-      val ncols = getNCols(header).toInt
-
-      for (col <- 0 to ncols-1) {
-        colTypes += FitsLib.shortStringValue(keyValues("TFORM" + (col + 1).toString))
+      this.selectedColNames = if (selectedColumns != null) {
+        selectedColumns
+      } else {
+        this.colNames.values.toList.asInstanceOf[List[String]]
       }
-      colTypes.result
+
+      // println(s"Selected columns = ${selectedColNames.toString}")
+
+      this.colPositions = selectedColNames.map(
+        x => getColumnPos(keyValues, x)).toList.sorted
+
+      this.rowTypes = if (empty_hdu) {
+        List[String]()
+      } else getColTypes(keyValues)
+      val ncols = rowTypes.size
+
+      // println(s"rowTypes = ${rowTypes.toString}")
+
+      // splitLocations is an array containing the location of elements
+      // (byte index) in a row. Example if we have a row with [20A, E, E], one
+      // will have splitLocations = [0, 20, 24, 28] that is a string on 20 Bytes,
+      // followed by 2 floats on 4 bytes each.
+      this.splitLocations = if (empty_hdu) {
+        List[Int]()
+      } else {
+        (0 :: rowSplitLocations(rowTypes, 0)).scan(0)(_ +_).tail
+      }
+      // println(s"handleBintable> rowTypes=${rowTypes.toString} colNames=${colNames.toString} colPositions=${colPositions.toString}")
+      this
     }
 
     def readMyType(name : String, fitstype : String, isNullable : Boolean = true): StructField = {
@@ -169,30 +331,5 @@ object FitsBintableLib {
         }
       }
     }
-
-    def listOfStruct : List[StructField] = {
-      // Grab max number of column
-      // Get the list of StructField.
-      val lStruct = List.newBuilder[StructField]
-
-      val cns = List.newBuilder[String]
-      for (colIndex <- colPositions) {
-        cns += colNames("TTYPE" + (colIndex + 1).toString)
-      }
-
-      // println(s"BintableInfos.listOfStruct> rowTypes=${rowTypes.toString} colPositions=${colPositions.toString} cns=${cns.toString}")
-
-      for (colIndex <- colPositions) {
-        val colName = FitsLib.shortStringValue(colNames("TTYPE" + (colIndex + 1).toString))
-
-        // println(s"listOfStruct> colname=${colName} rowType=${rowTypes(colIndex)}")
-
-        lStruct += readMyType(colName, rowTypes(colIndex))
-      }
-
-      lStruct.result
-
-    }
-
   }
 }

--- a/src/main/scala/com/sparkfits/FitsImage.scala
+++ b/src/main/scala/com/sparkfits/FitsImage.scala
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets
 
 import org.apache.spark.sql.types._
 
+import scala.util.Random
+
 /**
   * This is the beginning of a FITS library in Scala.
   * You will find a large number of methodes to manipulate Binary Table HDUs.
@@ -14,17 +16,8 @@ import org.apache.spark.sql.types._
   */
 object FitsImageLib {
   case class ImageInfos(pixelSize: Int, axis: Array[Long]) extends FitsLib.Infos {
-    def getRow(buf: Array[Byte]): List[Any] = {
-      var row = List.newBuilder[Any]
 
-      row += pixelSize
-      row += axis
-      row += buf
-
-      println(s"FitsImageLib.ImageInfos.getRow> pixelSize=$pixelSize axis=${axis.toString} buf=${buf.slice(0, 10).toString}")
-
-      row.result
-    }
+    def implemented: Boolean = {true}
 
     /**
       * Get the number of row of a HDU.
@@ -36,57 +29,19 @@ object FitsImageLib {
       * @return (Long), the number of rows as written in KEYWORD=NAXIS2.
       *
       */
-    def getNRows(header : Array[String]) : Long = {
-      val keyValues = FitsLib.parseHeader(header)
+    def getNRows(keyValues: Map[String, String]) : Long = {
+      // println(s"FitsImageLib.ImageInfos.getNRows> ")
+      ((axis.reduce(_ * _) * pixelSize) / getSizeRowBytes(keyValues)) + 1
+    }
+
+    def getSizeRowBytes(keyValues: Map[String, String]) : Int = {
+      // println(s"FitsImageLib.ImageInfos.getSizeRowBytes> ")
+      1024
+    }
+
+    def getNCols(keyValues : Map[String, String]) : Long = {
+      // println(s"FitsImageLib.ImageInfos.getNCols> ")
       1L
-    }
-
-    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {
-      val shortType = FitsLib.shortStringValue{fitstype}
-
-      shortType match {
-        // 16-bit Integer
-        case x if shortType.contains("I") => {
-          ByteBuffer.wrap(subbuf, 0, 2).getShort()
-        }
-        // 32-bit Integer
-        case x if shortType.contains("J") => {
-          ByteBuffer.wrap(subbuf, 0, 4).getInt()
-        }
-        // 64-bit Integer
-        case x if shortType.contains("K") => {
-          ByteBuffer.wrap(subbuf, 0, 8).getLong()
-        }
-        // Single precision floating-point
-        case x if shortType.contains("E") => {
-          ByteBuffer.wrap(subbuf, 0, 4).getFloat()
-        }
-        // Double precision floating-point
-        case x if shortType.contains("D") => {
-          ByteBuffer.wrap(subbuf, 0, 8).getDouble()
-        }
-        // Boolean
-        case x if shortType.contains("L") => {
-          // 1 Byte containing the ASCII char T(rue) or F(alse).
-          subbuf(0).toChar == 'T'
-        }
-        // Chain of characters
-        case x if shortType.endsWith("A") => {
-          // Example 20A means string on 20 bytes
-          new String(subbuf, StandardCharsets.UTF_8).trim()
-        }
-        case _ => {
-          println(s"""FitsLib.getElementFromBuffer> Cannot infer size of type $shortType from the header!
-              See getElementFromBuffer
-              """)
-          0
-        }
-      }
-    }
-
-    def getNCols(header : Array[String]) : Long = {
-      val keyValues = FitsLib.parseHeader(header)
-      0L
     }
 
     /**
@@ -98,26 +53,34 @@ object FitsImageLib {
       *   as given by the header.
       *
       */
-    def getColTypes(header : Array[String]): List[String] = {
+    def getColTypes(keyValues : Map[String, String]): List[String] = {
+      // println(s"FitsImageLib.ImageInfos.getColTypes> ")
       // Get the names of the Columns
-      val keyValues = FitsLib.parseHeader(header)
 
       val colTypes = List.newBuilder[String]
-
-      val ncols = getNCols(header).toInt
-      for (col <- 0 to ncols-1) {
-        colTypes += FitsLib.shortStringValue(keyValues("TFORM" + (col + 1).toString))
-      }
+      colTypes += "Image"
       colTypes.result
     }
 
     def listOfStruct : List[StructField] = {
+      // println(s"FitsImageLib.ImageInfos.listOfStruct> ")
       // Get the list of StructField.
+
       val lStruct = List.newBuilder[StructField]
-      lStruct += StructField("PixelSize", IntegerType, true)
-      lStruct += StructField("Axis", ArrayType(LongType, true), true)
-      lStruct += StructField("Image", ArrayType(ByteType, true), true)
+      lStruct += StructField("Image", ArrayType(ByteType, true))
       lStruct.result
+    }
+
+    def getRow(buf: Array[Byte]): List[Any] = {
+      val row = List.newBuilder[Any]
+      row += buf
+      row.result
+    }
+
+    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {
+      // println(s"FitsImageLib.ImageInfos.getElementFromBuffer> ")
+
+      subbuf
     }
   }
 }

--- a/src/main/scala/com/sparkfits/FitsImage.scala
+++ b/src/main/scala/com/sparkfits/FitsImage.scala
@@ -30,13 +30,35 @@ object FitsImageLib {
       *
       */
     def getNRows(keyValues: Map[String, String]) : Long = {
-      // println(s"FitsImageLib.ImageInfos.getNRows> ")
-      ((axis.reduce(_ * _) * pixelSize) / getSizeRowBytes(keyValues)) + 1
+      val totalBytes = axis.reduce(_ * _) * pixelSize
+      val rowBytes = getSizeRowBytes(keyValues)
+
+      val result = if (totalBytes % rowBytes == 0) {
+        (totalBytes / rowBytes).toLong
+      }
+      else {
+        ((totalBytes / rowBytes) + 1).toLong
+      }
+
+      println(s"FitsImageLib.ImageInfos.getNRows> result=$result")
+
+      result
     }
 
     def getSizeRowBytes(keyValues: Map[String, String]) : Int = {
       // println(s"FitsImageLib.ImageInfos.getSizeRowBytes> ")
-      1024
+      var size = (pixelSize * axis(0)).toInt
+      // Try and get the integer division factor until size becomes lower than 1024
+      var factor = 2
+      do {
+        if (size % factor == 0) {
+          size /= factor
+        }
+        else {
+          factor += 1
+        }
+      } while (size > 1024)
+      size
     }
 
     def getNCols(keyValues : Map[String, String]) : Long = {

--- a/src/main/scala/com/sparkfits/FitsImage.scala
+++ b/src/main/scala/com/sparkfits/FitsImage.scala
@@ -1,0 +1,123 @@
+package com.sparkfits
+
+import java.io.IOError
+import java.nio.ByteBuffer
+import java.io.EOFException
+import java.nio.charset.StandardCharsets
+
+import org.apache.spark.sql.types._
+
+/**
+  * This is the beginning of a FITS library in Scala.
+  * You will find a large number of methodes to manipulate Binary Table HDUs.
+  * There is no support for image HDU for the moment.
+  */
+object FitsImageLib {
+  case class ImageInfos(pixelSize: Int, axis: Array[Long]) extends FitsLib.Infos {
+    def getRow(buf: Array[Byte]): List[Any] = {
+      var row = List.newBuilder[Any]
+
+      row += pixelSize
+      row += axis
+      row += buf
+
+      println(s"FitsImageLib.ImageInfos.getRow> pixelSize=$pixelSize axis=${axis.toString} buf=${buf.slice(0, 10).toString}")
+
+      row.result
+    }
+
+    /**
+      * Get the number of row of a HDU.
+      * We rely on what's written in the header, meaning
+      * here we do not access the data directly.
+      *
+      * @param header : (Array[String])
+      *   The header of the HDU.
+      * @return (Long), the number of rows as written in KEYWORD=NAXIS2.
+      *
+      */
+    def getNRows(header : Array[String]) : Long = {
+      val keyValues = FitsLib.parseHeader(header)
+      1L
+    }
+
+    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {
+      val shortType = FitsLib.shortStringValue{fitstype}
+
+      shortType match {
+        // 16-bit Integer
+        case x if shortType.contains("I") => {
+          ByteBuffer.wrap(subbuf, 0, 2).getShort()
+        }
+        // 32-bit Integer
+        case x if shortType.contains("J") => {
+          ByteBuffer.wrap(subbuf, 0, 4).getInt()
+        }
+        // 64-bit Integer
+        case x if shortType.contains("K") => {
+          ByteBuffer.wrap(subbuf, 0, 8).getLong()
+        }
+        // Single precision floating-point
+        case x if shortType.contains("E") => {
+          ByteBuffer.wrap(subbuf, 0, 4).getFloat()
+        }
+        // Double precision floating-point
+        case x if shortType.contains("D") => {
+          ByteBuffer.wrap(subbuf, 0, 8).getDouble()
+        }
+        // Boolean
+        case x if shortType.contains("L") => {
+          // 1 Byte containing the ASCII char T(rue) or F(alse).
+          subbuf(0).toChar == 'T'
+        }
+        // Chain of characters
+        case x if shortType.endsWith("A") => {
+          // Example 20A means string on 20 bytes
+          new String(subbuf, StandardCharsets.UTF_8).trim()
+        }
+        case _ => {
+          println(s"""FitsLib.getElementFromBuffer> Cannot infer size of type $shortType from the header!
+              See getElementFromBuffer
+              """)
+          0
+        }
+      }
+    }
+
+    def getNCols(header : Array[String]) : Long = {
+      val keyValues = FitsLib.parseHeader(header)
+      0L
+    }
+
+    /**
+      * Return the types of elements for each column as a list.
+      *
+      * @param col : (Int)
+      *   Column index used for the recursion.
+      * @return (List[String]), list with the types of elements for each column
+      *   as given by the header.
+      *
+      */
+    def getColTypes(header : Array[String]): List[String] = {
+      // Get the names of the Columns
+      val keyValues = FitsLib.parseHeader(header)
+
+      val colTypes = List.newBuilder[String]
+
+      val ncols = getNCols(header).toInt
+      for (col <- 0 to ncols-1) {
+        colTypes += FitsLib.shortStringValue(keyValues("TFORM" + (col + 1).toString))
+      }
+      colTypes.result
+    }
+
+    def listOfStruct : List[StructField] = {
+      // Get the list of StructField.
+      val lStruct = List.newBuilder[StructField]
+      lStruct += StructField("PixelSize", IntegerType, true)
+      lStruct += StructField("Axis", ArrayType(LongType, true), true)
+      lStruct += StructField("Image", ArrayType(ByteType, true), true)
+      lStruct.result
+    }
+  }
+}

--- a/src/main/scala/com/sparkfits/FitsLib.scala
+++ b/src/main/scala/com/sparkfits/FitsLib.scala
@@ -22,7 +22,9 @@ import java.nio.charset.StandardCharsets
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.FSDataInputStream
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.types._
 
 import scala.util.{Try, Success, Failure}
 
@@ -43,6 +45,84 @@ object FitsLib {
 
   // Size of KEYWORD (KEYS) in FITS (bytes)
   val MAX_KEYWORD_LENGTH = 8
+
+  val separator = ";;"
+
+  def parseHeader(header : Array[String]) : Map[String, String] = {
+    /**
+      * Return the (key,values) of the header.
+      *
+      * @return (Map[String, String]), map array with (keys, values).
+      *
+      */
+    header.map(x => x.split("="))
+      .filter(x => x.size > 1)
+      .map(x => (x(0).trim(), x(1).split("/")(0).trim()))
+      // .map(x => (x._1, x._2))
+      .toMap
+  }
+
+  /**
+    * Class to hold block boundaries. These values are computed at first file scan
+    * then encoded to be broadcasted to all datanodes through the Hadoop configuration block.
+    *
+    * @param headerStart
+    * @param dataStart
+    * @param dataStop
+    * @param blockStop
+    */
+  case class FitsBlockBoundaries(headerStart: Long = 0L,
+                                 dataStart: Long = 0L,
+                                 dataStop: Long = 0L,
+                                 blockStop: Long = 0L) {
+
+    /**
+      * Register the boundaries of the HDU in the Hadoop configuration.
+      * By doing this, we broadcast the values to the executors.
+      * It is sent as a long String, and can be read properly
+      * afterwards using retrieveBlockBoundaries. Make sure you use the same
+      * separators.
+      *
+      */
+    def register(hdfsPath: Path, conf: Configuration) = {
+      val str = this.productIterator.toArray.mkString(separator)
+
+      conf.set(hdfsPath + "blockboundaries", str)
+    }
+
+    def empty = {
+      dataStart == dataStop
+    }
+
+    override def toString: String = {
+      s"[headerStart=$headerStart dataStart=$dataStart dataStop=$dataStop blockStop=$blockStop]"
+    }
+  }
+
+  trait Infos {
+    def getRow(buf: Array[Byte]): List[Any]
+    def listOfStruct : List[StructField]
+    def getNRows(header : Array[String]) : Long
+    def getNCols(header : Array[String]) : Long
+    def getColTypes(header : Array[String]): List[String]
+    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any
+  }
+
+  case class AnyInfos(hduType: String) extends Infos {
+    def getRow(buf: Array[Byte]): List[Any] = {null}
+    def listOfStruct : List[StructField] = {null}
+    def getNRows(header : Array[String]) : Long = {0L}
+    def getNCols(header : Array[String]) : Long = {0L}
+    def getColTypes(header : Array[String]): List[String] = {null}
+    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {null}
+  }
+
+  def shortStringValue(s: String) = {
+    if (s.startsWith("'") && s.endsWith("'")) {
+      s.slice(1, s.size - 1).trim
+    }
+    else {s}
+  }
 
   /**
     * Main class to handle a HDU of a fits file. Main features are
@@ -67,9 +147,12 @@ object FitsLib {
 
     // Check that the HDU asked is below the max HDU index.
     // Check only header no registered yet
-    val numberOfHdus = if (conf.get(hdfsPath+"_header") == null) {
+    // println(s"===================== FitsBlock-1> path=$hdfsPath hduIndex=$hduIndex")
+    val numberOfHdus = if (conf.get(hdfsPath + "_header") == null) {
       getNHDU
     } else hduIndex + 1
+
+    // println(s"FitsBlock-2> path=$hdfsPath hduIndex=$hduIndex numberOfHdus=$numberOfHdus")
 
     val isHDUBelowMax = hduIndex < numberOfHdus
     isHDUBelowMax match {
@@ -81,53 +164,215 @@ object FitsLib {
 
     // Compute the bound and initialise the cursor
     // indices (headerStart, dataStart, dataStop) in bytes.
-    val blockBoundaries = if (conf.get(hdfsPath+"_blockboundaries") != null) {
-      retrieveBlockBoundaries()
-    } else BlockBoundaries
+    val key = conf.get(hdfsPath + "_blockboundaries")
+    val blockBoundaries = if (key != null) {
+      // Retrieve the boundaries as a String, split it, and cast to Long
+      val arr = key.split(separator).map(x => x.toLong)
+      FitsBlockBoundaries(arr(0), arr(1), arr(2), arr(3))
+    } else {
+      getBlockBoundaries
+    }
 
-    val empty_hdu = if (blockBoundaries._2 == blockBoundaries._3) {
-      true
-    } else false
+    val empty_hdu = blockBoundaries.empty
 
     // Get the header and set the cursor to its start.
-    val blockHeader = if (conf.get(hdfsPath+"header") != null) {
+    val blockHeader = if (conf.get(hdfsPath + "header") != null) {
       retrieveHeader()
-    } else readHeader
+    } else readFullHeaderBlocks
     resetCursorAtHeader
 
-    hduType match {
-      case "BINTABLE" => hduType
-      case "EMPTY" => hduType
+    val infos: Infos = hduType match {
+      case "BINTABLE" => handleBintable(blockHeader, hduType)
+      case "TABLE" => handleTable(blockHeader, hduType)
+      case "IMAGE" => handleImage(blockHeader, hduType)
+      case "EMPTY" => AnyInfos(hduType)
       case _ => throw new AssertionError(s"""
         $hduType HDU not yet implemented!
         """)
     }
 
-    // Get informations on element types and number of columns.
-    val rowTypes = if (empty_hdu) {
-      List[String]()
-    } else getColTypes(blockHeader)
-    val ncols = rowTypes.size
+    /**
+      * =============== end of FitBlock main code =========================================
+      */
 
-    // Check if the user specifies columns to select
-    val colNames = getHeaderNames(blockHeader)
-
-    val selectedColNames = if (conf.get("columns") != null) {
-      conf.getStrings("columns").deep.toList.asInstanceOf[List[String]]
-    } else {
-      colNames.filter(x=>x._1.contains("TYPE")).values.toList.asInstanceOf[List[String]]
+    def handleTable(blockHeader: Array[String], hduType: String) = {
+      println(s"handleTable> blockHeader=${blockHeader.toString}")
+      FitsTableLib.TableInfos()
     }
-    val colPositions = selectedColNames.map(
-      x=>getColumnPos(blockHeader, x)).toList.sorted
 
-    // splitLocations is an array containing the location of elements
-    // (byte index) in a row. Example if we have a row with [20A, E, E], one
-    // will have splitLocations = [0, 20, 24, 28] that is a string on 20 Bytes,
-    // followed by 2 floats on 4 bytes each.
-    val splitLocations = if (empty_hdu) {
-      List[Int]()
-    } else {
-      (0 :: rowSplitLocations(0)).scan(0)(_ +_).tail
+    def handleImage(blockHeader: Array[String], hduType: String) = {
+      println(s"handleImage> blockHeader=${blockHeader.toString}")
+
+      val kv = parseHeader(blockHeader)
+
+      val pixelSize = (kv("BITPIX").toInt)/8
+      val dimensions = kv("NAXIS").toInt
+      val axis = Array.newBuilder[Long]
+      for (d <- 1 to dimensions){
+        axis += kv("NAXIS" + d.toString).toLong
+      }
+      FitsImageLib.ImageInfos(pixelSize, axis.result)
+    }
+
+    // Get informations on element types and number of columns.
+    def handleBintable(blockHeader: Array[String], hduType: String) = {
+
+      /**
+        * Description of a row in terms of bytes indices.
+        * rowSplitLocations returns an array containing the position of elements
+        * (byte index) in a row. Example if we have a row with [20A, E, E], one
+        * will have rowSplitLocations -> [0, 20, 24, 28] that is a string
+        * on 20 Bytes, followed by 2 floats on 4 bytes each.
+        *
+        * @param col : (Int)
+        *   Column position used for the recursion. Should be left at 0.
+        * @return (List[Int]), the position of elements (byte index) in a row.
+        *
+        */
+      def rowSplitLocations(rowTypes: List[String], col : Int = 0) : List[Int] = {
+        val ncols = rowTypes.size
+
+        if (col == ncols) {
+          Nil
+        } else {
+          getSplitLocation(rowTypes(col)) :: rowSplitLocations(rowTypes, col + 1)
+        }
+      }
+
+      /**
+        * Companion routine to rowSplitLocations. Returns the size of a primitive
+        * according to its type from the FITS header.
+        *
+        * @param fitstype : (String)
+        *   Element type according to FITS standards (I, J, K, E, D, L, A, etc)
+        * @return (Int), the size (bytes) of the element.
+        *
+        */
+      def getSplitLocation(fitstype : String) : Int = {
+        val shortType = shortStringValue(fitstype)
+
+        shortType match {
+          case x if shortType.contains("I") => 2
+          case x if shortType.contains("J") => 4
+          case x if shortType.contains("K") => 8
+          case x if shortType.contains("E") => 4
+          case x if shortType.contains("D") => 8
+          case x if shortType.contains("L") => 1
+          case x if shortType.endsWith("A") => {
+            // Example 20A means string on 20 bytes
+            x.slice(0, x.length - 1).toInt
+          }
+          case _ => {
+            println(s"""FitsLib.getSplitLocation> Cannot infer size of type $shortType from the header!
+              See com.sparkfits.FitsLib.getSplitLocation
+              """)
+            0
+          }
+        }
+      }
+
+      val localInfos = FitsBintableLib.BintableInfos()
+
+      val rowTypes = if (empty_hdu) {
+        List[String]()
+      } else localInfos.getColTypes(blockHeader)
+      val ncols = rowTypes.size
+
+      // Check if the user specifies columns to select
+      val colNames = parseHeader(blockHeader).
+        filter(x => x._1.contains("TTYPE")).
+        map(x => (x._1, x._2.split("'")(1).trim()))
+
+      val selectedColNames = if (conf.get("columns") != null) {
+        conf.getStrings("columns").deep.toList.asInstanceOf[List[String]]
+      } else {
+        colNames.values.toList.asInstanceOf[List[String]]
+      }
+
+      // println(s"Selected columns = ${selectedColNames.toString}")
+
+      val colPositions = selectedColNames.map(
+        x => getColumnPos(blockHeader, x)).toList.sorted
+
+      // splitLocations is an array containing the location of elements
+      // (byte index) in a row. Example if we have a row with [20A, E, E], one
+      // will have splitLocations = [0, 20, 24, 28] that is a string on 20 Bytes,
+      // followed by 2 floats on 4 bytes each.
+      val splitLocations = if (empty_hdu) {
+        List[Int]()
+      } else {
+        (0 :: rowSplitLocations(rowTypes, 0)).scan(0)(_ +_).tail
+      }
+
+      // println(s"handleBintable> rowTypes=${rowTypes.toString} colNames=${colNames.toString} colPositions=${colPositions.toString}")
+
+      localInfos.initialize(rowTypes, colNames, selectedColNames, colPositions, splitLocations)
+
+      localInfos
+    }
+
+    def getBlockBoundaries: FitsBlockBoundaries = {
+
+      // Initialise the cursor position at the beginning of the file
+      data.seek(0)
+      var hduTmp = 0
+
+      // Initialise the boundaries
+      var headerStart : Long = 0
+      var dataStart : Long = 0
+      var dataStop : Long = 0
+      var blockStop : Long = 0
+
+      // println(s"====== getBlockBoundaries> data.getPos=${data.getPos}")
+
+      // Loop over HDUs, and stop at the desired one.
+      do {
+        // Initialise the offset to the header position
+        headerStart = data.getPos
+
+        // println(s"getBlockBoundaries-1) data.getPos=${data.getPos}")
+
+        val localHeader = readFullHeaderBlocks
+
+        // Data block starts after the header
+        dataStart = data.getPos
+
+        val keyValues = parseHeader(localHeader)
+
+        // println(s"keyvalues=${keyValues.mkString("\n")}")
+
+        // Size of the data block in Bytes.
+        // Skip Data if None (typically HDU=0)
+        val data_len = Try {
+          getDataLen(keyValues)
+        }.getOrElse(0L)
+
+        // Where the actual data stopped
+        dataStop = dataStart + data_len
+
+        // Store the final offset
+        // FITS is made of blocks of size 2880 bytes, so we might need to
+        // pad to jump from the end of the data to the next header.
+        blockStop = if ((dataStart + data_len) % FITSBLOCK_SIZE_BYTES == 0) {
+          dataStop
+        } else {
+          dataStop + FITSBLOCK_SIZE_BYTES -  (dataStop) % FITSBLOCK_SIZE_BYTES
+        }
+
+        // Move to the another HDU if needed
+        hduTmp = hduTmp + 1
+        data.seek(blockStop)
+
+      } while (hduTmp < hduIndex + 1)
+
+      // Reposition the cursor at the beginning of the block
+      data.seek(headerStart)
+
+      // Return boundaries (included):
+      // hdu_start=headerStart, dataStart, dataStop, hdu_stop
+      val fb = FitsBlockBoundaries(headerStart, dataStart, dataStop, blockStop)
+      // println(s"getBlockBoundaries-END> $fb")
+      fb
     }
 
     /**
@@ -168,7 +413,7 @@ object FitsLib {
       * Compute the size of a data block.
       *
       * @param values : (Map[String, String])
-      *   Values from the header (see getHeaderValues)
+      *   Values from the header (see parseHeader)
       * @return (Long) Size of the corresponding data block
       *
       */
@@ -193,70 +438,6 @@ object FitsLib {
     }
 
     /**
-      * Return the indices of the first and last bytes of the HDU:
-      * hdu_start=header_start, data_start, data_stop, hdu_stop
-      *
-      * @return (Long, Long, Long, Long), the split of the HDU.
-      *
-      */
-    def BlockBoundaries : (Long, Long, Long, Long) = {
-
-      // Initialise the cursor position at the beginning of the file
-      data.seek(0)
-      var hdu_tmp = 0
-
-      // Initialise the boundaries
-      var header_start : Long = 0
-      var data_start : Long = 0
-      var data_stop : Long = 0
-      var block_stop : Long = 0
-
-      // Loop over HDUs, and stop at the desired one.
-      do {
-        // Initialise the offset to the header position
-        header_start = data.getPos
-
-        // println(s"1) data.getPos=${data.getPos}")
-
-        // add the header size (and move after it)
-        val localHeader = readHeader
-
-        // Data block starts after the header
-        data_start = data.getPos
-
-        // Size of the data block in Bytes.
-        // Skip Data if None (typically HDU=0)
-        val data_len = Try {
-          getDataLen(getHeaderValues(localHeader))
-        }.getOrElse(0L)
-
-        // Where the actual data stopped
-        data_stop = data_start + data_len
-
-        // Store the final offset
-        // FITS is made of blocks of size 2880 bytes, so we might need to
-        // pad to jump from the end of the data to the next header.
-        block_stop = if ((data_start + data_len) % FITSBLOCK_SIZE_BYTES == 0) {
-          data_stop
-        } else {
-          data_stop + FITSBLOCK_SIZE_BYTES -  (data_stop) % FITSBLOCK_SIZE_BYTES
-        }
-
-        // Move to the another HDU if needed
-        hdu_tmp = hdu_tmp + 1
-        data.seek(block_stop)
-
-      } while (hdu_tmp < hduIndex + 1 )
-
-      // Reposition the cursor at the beginning of the block
-      data.seek(header_start)
-
-      // Return boundaries (included):
-      // hdu_start=header_start, data_start, data_stop, hdu_stop
-      (header_start, data_start, data_stop, block_stop)
-    }
-
-    /**
       * Return the number of HDUs in the file.
       *
       * @return (Int) the number of HDU.
@@ -266,47 +447,57 @@ object FitsLib {
 
       // Initialise the file
       data.seek(0)
-      var hdu_tmp = 0
+      var currentHduIndex = 0
 
-      // Initialise the boundaries
-      var data_stop : Long = 0
-      var e : Boolean = true
+      var hasData : Boolean = true
+      var datalen = 0L
 
       // Loop over all HDU, and exit.
       do {
+        // println(s"\ngetNHDU-1) hdu=$currentHduIndex data.getPos=${data.getPos}")
 
-        // Get the header (and move after it)
-        // Could be better handled with Try/Success/Failure.
-        val localHeader = Try{readHeader}.getOrElse(Array[String]())
+        hasData = false
+        val localHeader = readFullHeaderBlocks
 
         // If the header cannot be read,
-        e = if (localHeader.size == 0) {
-          false
-        } else true
+        if (localHeader.size > 0) {
+          hasData = true
 
-        // Size of the data block in Bytes.
-        // Skip Data if None (typically HDU=0)
-        val datalen = Try {
-          getDataLen(getHeaderValues(localHeader))
-        }.getOrElse(0L)
+          // Size of the data block in Bytes.
+          // Skip Data if None (typically HDU=0)
+          datalen = Try {
+            getDataLen(parseHeader(localHeader))
+          }.getOrElse(0L)
 
-        // Store the final offset
-        // FITS is made of blocks of size 2880 bytes, so we might need to
-        // pad to jump from the end of the data to the next header.
-        data_stop = if ((data.getPos + datalen) % FITSBLOCK_SIZE_BYTES == 0) {
-          data.getPos + datalen
-        } else {
-          data.getPos + datalen + FITSBLOCK_SIZE_BYTES -  (data.getPos + datalen) % FITSBLOCK_SIZE_BYTES
+          // println(s"getNHDU-2) header=${localHeader.size} datalen=$datalen data.getPos=${data.getPos}")
+
+          // Store the offset to the next HDU
+          // FITS is made of blocks of size 2880 bytes, both for the headers and for the data
+          // if datalen is not null, it must be justified to an integer number of blocks
+          val skipBytes = if (datalen % FITSBLOCK_SIZE_BYTES == 0) {
+            datalen
+          }
+          else {
+            datalen + FITSBLOCK_SIZE_BYTES - (datalen % FITSBLOCK_SIZE_BYTES)
+          }
+
+          // println(s"getNHDU-3) header=${localHeader.size} data.getPos=${data.getPos} datalen=$datalen skipBytes=$skipBytes")
+
+          data.seek(data.getPos + skipBytes)
+
+          // Move to the another HDU if needed
+          currentHduIndex = currentHduIndex + 1
+        }
+        else {
+          // println(s"getNHDU-4) has no data")
         }
 
-        // Move to the another HDU if needed
-        hdu_tmp = hdu_tmp + 1
-        data.seek(data_stop)
+      } while (hasData)
 
-      } while (e)
+      // println(s"getNHDU-END) data.getPos=${data.getPos} currentHduIndex=$currentHduIndex")
 
       // Return the number of HDU.
-      hdu_tmp - 1
+      currentHduIndex
     }
 
     /**
@@ -315,7 +506,7 @@ object FitsLib {
       */
     def resetCursorAtHeader = {
       // Place the cursor at the beginning of the block
-      data.seek(blockBoundaries._1)
+      data.seek(blockBoundaries.headerStart)
     }
 
     /**
@@ -324,7 +515,7 @@ object FitsLib {
       */
     def resetCursorAtData = {
       // Place the cursor at the beginning of the block
-      data.seek(blockBoundaries._2)
+      data.seek(blockBoundaries.dataStart)
     }
 
     /**
@@ -343,7 +534,7 @@ object FitsLib {
       *
       * @param position : (Long)
       *   The byte index to seek in the file. Need to correspond to a valid
-      *   header position. Use in combination with BlockBoundaries._1
+      *   header position. Use in combination with BlockBoundaries.headerStart
       *   for example.
       * @return (Array[String) the header is an array of Strings, each String
       *   being one line of the header.
@@ -351,6 +542,101 @@ object FitsLib {
     def readHeader(position : Long) : Array[String] = {
       setCursor(position)
       readHeader
+    }
+
+    def readFullHeaderBlocks : Array[String] = {
+      // println(s"readFullHeaderBlocks> data.getPos=${data.getPos}")
+      var header = Array.newBuilder[String]
+      var ending = false
+      var blockNumber = 0
+      do {
+        val block = readHeaderBlock
+        ending = block.size == 0
+        // println(s"readFullHeaderBlocks> block.size=${block.size}")
+
+        if (!ending)
+          {
+            var first = true
+            var last = ""
+            var s = s"readFullHeaderBlocks> add lines \n"
+
+            for
+              {
+                line <- block
+                if line.trim() != ""} {
+
+                if (line.trim() == "END") ending = true
+
+                if (first)
+                {
+                  s += s"$line"
+                  first = false
+                }
+
+                last = line
+                header += line
+              }
+            // println(s"$s ... $last")
+          } else {
+            // println("readFullHeaderBlocks> ending")
+          }
+
+        // println(s"readFullHeaderBlocks-$blockNumber) fullHeader=${header.result.size} END=${ending}")
+        blockNumber += 1
+      } while (!ending)
+      header.result
+    }
+
+    def readHeaderBlock : Array[String] = {
+      // Initialise a line of the header
+      var buffer = new Array[Byte](FITSBLOCK_SIZE_BYTES)
+
+      // println(s"readHeaderBlock> data.getPos=${data.getPos}")
+
+      val header = Array.newBuilder[String]
+
+      val len = try {
+        data.read(buffer, 0, FITSBLOCK_SIZE_BYTES)
+      } catch {
+        case e : Exception => { e.printStackTrace; 0}
+      }
+
+      if (len > 0) {
+        /*
+        val window = 80
+        val begining = new String(buffer.slice(0, window), StandardCharsets.UTF_8)
+        val trailer = new String(buffer.slice(len-window, len), StandardCharsets.UTF_8)
+        println(s"readHeaderBlock> data.getPos=${data.getPos} len=$len buffer=\n[${begining}\n...\n${trailer}]")
+        */
+
+        val maxLines = FITSBLOCK_SIZE_BYTES / FITS_HEADER_CARD_SIZE
+
+        var inBlock = true
+
+        var pos = 0
+
+        for {
+          i <- 0 to maxLines-1
+          if inBlock} {
+          val line = new String(buffer.slice(pos, pos + FITS_HEADER_CARD_SIZE), StandardCharsets.UTF_8)
+
+          // println(s"=== $i $line")
+          /*
+          if (line.trim != "" && !line.startsWith("COMMENT")) {
+            header += line
+          }
+          */
+          header += line
+
+          if (line.trim() == "END") {
+            // println(s"readHeaderBlock-END> pos=$pos getPos=${data.getPos} modulo=${data.getPos % FITSBLOCK_SIZE_BYTES} block=${data.getPos/FITSBLOCK_SIZE_BYTES}")
+            inBlock = false
+          }
+          pos += FITS_HEADER_CARD_SIZE
+        }
+      }
+
+      header.result
     }
 
     /**
@@ -417,24 +703,6 @@ object FitsLib {
     }
 
     /**
-      * Register the boundaries of the HDU in the Hadoop configuration.
-      * By doing this, we broadcast the values to the executors.
-      * It is sent as a long String, and can be read properly
-      * afterwards using retrieveBlockBoundaries. Make sure you use the same
-      * separators.
-      *
-      * @param sep : (String)
-      *   Line separator used to form the String. Default is ;;
-      *
-      */
-    def registerBlockBoundaries(sep : String=";;") {
-      // Register the Tuple4 as a String.. Ugly
-      val str = blockBoundaries.productIterator.toArray.mkString(sep)
-
-      conf.set(hdfsPath+"blockboundaries", str)
-    }
-
-    /**
       * Retrieve the header from the Hadoop configuration.
       * Make sure you use the same separators as in registerHeader.
       *
@@ -449,28 +717,11 @@ object FitsLib {
     }
 
     /**
-      * Retrieve the blockboundaries from the Hadoop configuration.
-      * Make sure you use the same separators as in registerBlockBoundaries.
-      *
-      * @param sep : (String)
-      *   Line separator used to split the String. Default is ;;
-      * @return the block boundaries as Tuple4 of Long. See BlockBoundaries.
-      *
-      */
-    def retrieveBlockBoundaries(sep : String=";;"): (Long, Long, Long, Long) = {
-      // Retrieve the boundaries as a String, split it, and cast to Long
-      val arr = conf.get(hdfsPath+"blockboundaries").split(sep).map(x => x.toLong)
-
-      // Return it as a tuple4 of Long... Ugly... Need to change that!
-      (arr(0), arr(1), arr(2), arr(3))
-    }
-
-    /**
       * Convert binary row into row. You need to have the cursor at the
       * beginning of a row. Example
       * {{{
       * // Set the cursor at the beginning of the data block
-      * setCursor(BlockBoundaries._2)
+      * setCursor(BlockBoundaries.dataStart)
       * // Initialise your binary row
       * val buffer = Array[Byte](size_of_one_row_in_bytes)
       * // Read the first binary row into buffer
@@ -486,89 +737,12 @@ object FitsLib {
       *
       */
     def readLineFromBuffer(buf : Array[Byte]): List[_] = {
-
-      val row = List.newBuilder[Any]
-      for (col <- colPositions) {
-        row += getElementFromBuffer(
-          buf.slice(splitLocations(col), splitLocations(col+1)), rowTypes(col))
+      if (hduType == "BINTABLE" || hduType == "IMAGE") {
+        infos.getRow(buf)
       }
-      row.result
+      else null
     }
 
-    /**
-      * Companion to readLineFromBuffer. Convert one array of bytes
-      * corresponding to one element of the table into its primitive type.
-      *
-      * @param subbuf : (Array[Byte])
-      *   Array of byte describing one element of the table.
-      * @param fitstype : (String)
-      *   The type of this table element according to the header.
-      * @return the table element converted from binary.
-      *
-      */
-    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {
-      fitstype match {
-        // 16-bit Integer
-        case x if fitstype.contains("I") => {
-          ByteBuffer.wrap(subbuf, 0, 2).getShort()
-        }
-        // 32-bit Integer
-        case x if fitstype.contains("J") => {
-          ByteBuffer.wrap(subbuf, 0, 4).getInt()
-        }
-        // 64-bit Integer
-        case x if fitstype.contains("K") => {
-          ByteBuffer.wrap(subbuf, 0, 8).getLong()
-        }
-        // Single precision floating-point
-        case x if fitstype.contains("E") => {
-          ByteBuffer.wrap(subbuf, 0, 4).getFloat()
-        }
-        // Double precision floating-point
-        case x if fitstype.contains("D") => {
-          ByteBuffer.wrap(subbuf, 0, 8).getDouble()
-        }
-        // Boolean
-        case x if fitstype.contains("L") => {
-          // 1 Byte containing the ASCII char T(rue) or F(alse).
-          subbuf(0).toChar == 'T'
-        }
-        // Chain of characters
-        case x if fitstype.endsWith("A") => {
-          // Example 20A means string on 20 bytes
-          new String(subbuf, StandardCharsets.UTF_8).trim()
-        }
-        case _ => {
-          println(s"""
-              Cannot infer size of type $fitstype from the header!
-              See com.sparkfits.FitsLib.getElementFromBuffer
-              """)
-          0
-        }
-      }
-    }
-
-    /**
-      * Return the types of elements for each column as a list.
-      *
-      * @param col : (Int)
-      *   Column index used for the recursion.
-      * @return (List[String]), list with the types of elements for each column
-      *   as given by the header.
-      *
-      */
-    def getColTypes(header : Array[String], col : Int = 0): List[String] = {
-      // Get the names of the Columns
-      val headerNames = getHeaderNames(header)
-
-      // Get the number of Columns by recursion
-      val ncols = getNCols(header)
-      if (col == ncols) {
-        Nil
-      } else {
-        headerNames("TFORM" + (col + 1).toString) :: getColTypes(header, col + 1)
-      }
-    }
 
     /**
       * Return the KEYWORDS of the header.
@@ -587,31 +761,6 @@ object FitsLib {
         keywords(i) = line.substring(0, MAX_KEYWORD_LENGTH).trim()
       }
       keywords
-    }
-
-    /**
-      * Return the numerical values of the header.
-      *
-      * @return (Map[String, String]), map array with (keys, values).
-      *
-      */
-    def getHeaderValues(header : Array[String]) : Map[String, String] = {
-
-      // Get the KEYWORDS of the Header
-      val keys = getHeaderKeywords(header)
-
-      // Filter values
-      val headerMap = header.map(x => x.split("="))
-          .filter(x => x.size > 1)
-          // (KEYWORD, NON-COMMENT)
-          .map(x => (x(0).trim(), x(1).split("/")(0).trim()))
-          .filter(x => !x._2.startsWith("'"))
-          // (KEYWORD, numerical values)
-          .map(x => (x._1, x._2))
-          .toMap
-
-      // Return the map(KEYWORDS -> VALUES)
-      headerMap
     }
 
     /**
@@ -665,36 +814,6 @@ object FitsLib {
     }
 
     /**
-      * Get the number of row of a HDU.
-      * We rely on what's written in the header, meaning
-      * here we do not access the data directly.
-      *
-      * @param header : (Array[String])
-      *   The header of the HDU.
-      * @return (Long), the number of rows as written in KEYWORD=NAXIS2.
-      *
-      */
-    def getNRows(header : Array[String]) : Long = {
-      val values = getHeaderValues(header)
-      values("NAXIS2").toLong
-    }
-
-    /**
-      * Get the number of column of a HDU.
-      * We rely on what's written in the header, meaning
-      * here we do not access the data directly.
-      *
-      * @param header : (Array[String])
-      *   The header of the HDU.
-      * @return (Long), the number of rows as written in KEYWORD=TFIELDS.
-      *
-      */
-    def getNCols(header : Array[String]) : Long = {
-      val values = getHeaderValues(header)
-      values("TFIELDS").toLong
-    }
-
-    /**
       * Get the size (bytes) of each row of a HDU.
       * We rely on what's written in the header, meaning
       * here we do not access the data directly.
@@ -705,8 +824,9 @@ object FitsLib {
       *
       */
     def getSizeRowBytes(header : Array[String]) : Int = {
-      val values = getHeaderValues(header)
-      values("NAXIS1").toInt
+      val keyValues = parseHeader(header)
+      //getDataLen(keyValues).toInt
+      keyValues("NAXIS1").toInt
     }
 
     /**
@@ -721,9 +841,9 @@ object FitsLib {
       */
     def getColumnName(header : Array[String], colIndex : Int) : String = {
       // Grab the header names as map(keywords/names)
-      val names = getHeaderNames(header)
+      val keyValues = parseHeader(header)
       // Zero-based index
-      names("TTYPE" + (colIndex + 1).toString)
+      keyValues("TTYPE" + (colIndex + 1).toString)
     }
 
     /**
@@ -738,11 +858,22 @@ object FitsLib {
       */
     def getColumnPos(header : Array[String], colName : String) : Int = {
       // Grab the header names as map(keywords/names)
-      val names = getHeaderNames(header)
+      val keyValues = parseHeader(header)
+
+      val v = keyValues.
+        filter(x => x._1.contains("TTYPE")).
+        map(x => (x._1, x._2.split("'")(1).trim())).
+        values
+
+      // println(s"getColumnPos> v=${v.toString} colName=$colName")
 
       // Get the position of the column. Header names are TTYPE#
       val pos = Try {
-        names.filter(x => x._2.toLowerCase == colName.toLowerCase).keys.head.substring(5).toInt
+        keyValues.
+          filter(x => x._1.contains("TTYPE")).
+          map(x => (x._1, x._2.split("'")(1).trim())).
+          filter(x => x._2.toLowerCase == colName.toLowerCase).
+          keys.head.substring(5).toInt
       }.getOrElse(-1)
 
       val isCol = pos >= 0
@@ -769,60 +900,10 @@ object FitsLib {
       */
     def getColumnType(header : Array[String], colIndex : Int) : String = {
       // Grab the header names as map(keywords/names)
-      val names = getHeaderNames(header)
+      val keyValues = parseHeader(header)
       // Zero-based index
-      names("TFORM" + (colIndex + 1).toString)
+      keyValues("TFORM" + (colIndex + 1).toString)
     }
 
-    /**
-      * Description of a row in terms of bytes indices.
-      * rowSplitLocations returns an array containing the position of elements
-      * (byte index) in a row. Example if we have a row with [20A, E, E], one
-      * will have rowSplitLocations -> [0, 20, 24, 28] that is a string
-      * on 20 Bytes, followed by 2 floats on 4 bytes each.
-      *
-      * @param col : (Int)
-      *   Column position used for the recursion. Should be left at 0.
-      * @return (List[Int]), the position of elements (byte index) in a row.
-      *
-      */
-    def rowSplitLocations(col : Int = 0) : List[Int] = {
-      if (col == ncols) {
-        Nil
-      } else {
-        getSplitLocation(rowTypes(col)) :: rowSplitLocations(col + 1)
-      }
-    }
-
-    /**
-      * Companion routine to rowSplitLocations. Returns the size of a primitive
-      * according to its type from the FITS header.
-      *
-      * @param fitstype : (String)
-      *   Element type according to FITS standards (I, J, K, E, D, L, A, etc)
-      * @return (Int), the size (bytes) of the element.
-      *
-      */
-    def getSplitLocation(fitstype : String) : Int = {
-      fitstype match {
-        case x if fitstype.contains("I") => 2
-        case x if fitstype.contains("J") => 4
-        case x if fitstype.contains("K") => 8
-        case x if fitstype.contains("E") => 4
-        case x if fitstype.contains("D") => 8
-        case x if fitstype.contains("L") => 1
-        case x if fitstype.endsWith("A") => {
-          // Example 20A means string on 20 bytes
-          x.slice(0, x.length - 1).toInt
-        }
-        case _ => {
-          println(s"""
-              Cannot infer size of type $fitstype from the header!
-              See com.sparkfits.FitsLib.getSplitLocation
-              """)
-          0
-        }
-      }
-    }
   }
 }

--- a/src/main/scala/com/sparkfits/FitsRecordReader.scala
+++ b/src/main/scala/com/sparkfits/FitsRecordReader.scala
@@ -144,6 +144,7 @@ class FitsRecordReader extends RecordReader[LongWritable, Seq[Row]] {
     */
   override def initialize(inputSplit: InputSplit, context: TaskAttemptContext) {
 
+    // println(s"FitsRecordReader.initialize> ")
     // Hadoop description of the input file (Path, split, start/stop indices).
     val fileSplit = inputSplit.asInstanceOf[FileSplit]
 
@@ -159,7 +160,6 @@ class FitsRecordReader extends RecordReader[LongWritable, Seq[Row]] {
 
     // Initialise our block (header + data)
     fB = new FitsBlock(file, conf, conf.get("hdu").toInt)
-    // fB = new FitsBlock(file, conf, 1)
 
     // Define the bytes indices of our block
     // hdu_start=header_start, dataStart, dataStop, hdu_stop
@@ -167,12 +167,15 @@ class FitsRecordReader extends RecordReader[LongWritable, Seq[Row]] {
 
     // Get the header
     header = fB.blockHeader
+    val keyValues = FitsLib.parseHeader(header)
 
     // Get the number of rows and the size (B) of one row.
     // this is dependent on the HDU type
-    nrowsLong = fB.infos.getNRows(header)
-    rowSizeInt = fB.getSizeRowBytes(header)
+    nrowsLong = fB.infos.getNRows(keyValues)
+    rowSizeInt = fB.infos.getSizeRowBytes(keyValues)
     rowSizeLong = rowSizeInt.toLong
+
+    // println(s"FitsRecordReader.initialize> nrowsLong=$nrowsLong rowSizeInt=$rowSizeInt")
 
     // What Hadoop gave us
     val start_theo = fileSplit.getStart

--- a/src/main/scala/com/sparkfits/FitsSchema.scala
+++ b/src/main/scala/com/sparkfits/FitsSchema.scala
@@ -49,8 +49,7 @@ object FitsSchema {
       case x if fitstype.contains("L") => StructField(name, BooleanType, isNullable)
       case x if fitstype.contains("A") => StructField(name, StringType, isNullable)
       case _ => {
-        println(s"""
-            Cannot infer type $fitstype from the header!
+        println(s"""FitsSchema.ReadMyType> Cannot infer type $fitstype from the header!
             See com.sparkfits.FitsSchema.scala
             """)
         StructField(name, StringType, isNullable)
@@ -74,17 +73,14 @@ object FitsSchema {
 
     // Read the header
     val header = fB.blockHeader
-    checkBintableHeader(header)
+    checkAnyHeader(header)
 
-    // Grab max number of column
-    val colmax = fB.getNCols(header)
-
-    // Get the list of StructField.
-    val lStruct = List.newBuilder[StructField]
-    for (col <- fB.colPositions) {
-      lStruct += ReadMyType(fB.getColumnName(header, col), fB.getColumnType(header, col))
+    if (checkBintableHeader(header)){
+      fB.infos.listOfStruct
     }
-    lStruct.result
+    else {
+      List[StructField]()
+    }
   }
 
   /**
@@ -113,34 +109,21 @@ object FitsSchema {
   }
 
   /**
-    * A few checks on the header for bintable.
-    * Careful, it will throw errors for image!
+    * A few checks on the header for any header type
     *
     * @param header : (Array[String])
     *   The header of the HDU.
     */
-  def checkBintableHeader(header : Array[String]) : Unit = {
+  def checkAnyHeader(header : Array[String]) : Unit = {
 
     // Check that we have an extension
     val keysHasXtension = header(0).contains("XTENSION")
     keysHasXtension match {
       case true => keysHasXtension
       case false => throw new AssertionError("""
-        Are you really trying to read a BINTABLE?
         Your header has no keywords called XTENSION.
         Check that the HDU number you want to
         access is correct: spark.readfits.option("HDU", <Int>).
-        """)
-    }
-
-    // Check that we read a bintable
-    val headerStart = header(0).contains("BINTABLE")
-    val headerStartElement = header(0)
-    headerStart match {
-      case true => headerStart
-      case false => throw new AssertionError(s"""
-        Are you really trying to read a BINTABLE? Your header says that
-        the XTENSION is $headerStartElement
         """)
     }
 
@@ -155,4 +138,17 @@ object FitsSchema {
         """)
     }
   }
+
+  /**
+    * Verify if the header is a bintable.
+    *
+    * @param header : (Array[String])
+    *   The header of the HDU.
+    */
+  def checkBintableHeader(header : Array[String]) : Boolean = {
+
+    // Check that we read a bintable
+    header(0).contains("BINTABLE")
+  }
+
 }

--- a/src/main/scala/com/sparkfits/FitsSchema.scala
+++ b/src/main/scala/com/sparkfits/FitsSchema.scala
@@ -75,7 +75,7 @@ object FitsSchema {
     val header = fB.blockHeader
     checkAnyHeader(header)
 
-    if (checkBintableHeader(header)){
+    if (fB.infos.implemented){
       fB.infos.listOfStruct
     }
     else {
@@ -138,17 +138,4 @@ object FitsSchema {
         """)
     }
   }
-
-  /**
-    * Verify if the header is a bintable.
-    *
-    * @param header : (Array[String])
-    *   The header of the HDU.
-    */
-  def checkBintableHeader(header : Array[String]) : Boolean = {
-
-    // Check that we read a bintable
-    header(0).contains("BINTABLE")
-  }
-
 }

--- a/src/main/scala/com/sparkfits/FitsSourceRelation.scala
+++ b/src/main/scala/com/sparkfits/FitsSourceRelation.scala
@@ -160,7 +160,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     // Check that we have at least one file
     listOfFitsFiles.size match {
       case x if x > 0 => if (verbosity) {
-        println("Found " + listOfFitsFiles.size.toString + " file(s):")
+        println("FitsRelation.searchFitsFile> Found " + listOfFitsFiles.size.toString + " file(s):")
         listOfFitsFiles.foreach(println)
       }
       case x if x <= 0 => throw new NullPointerException(s"""
@@ -203,7 +203,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     *   NOT UNDERSTOOD if not registered.
     *
     */
-  def checkSchemaAndReturnType(listOfFitsFiles : List[String]): String = {
+  def checkSchemaAndReturnType(listOfFitsFiles : List[String]): Boolean = {
     // Wanted HDU
     val indexHDU = conf.get("hdu").toInt
 
@@ -211,9 +211,8 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     val path_init = new Path(listOfFitsFiles(0))
 
     val fB_init = new FitsBlock(path_init, conf, indexHDU)
-    val fitstype = fB_init.hduType
 
-    val check = if (fitstype == "BINTABLE" || fitstype == "IMAGE") {
+    if (fB_init.infos.implemented) {
       val schema_init = getSchema(fB_init)
       fB_init.data.close()
 
@@ -225,10 +224,10 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
         isOk match {
           case true => isOk
           case false => {
-            println(listOfFitsFiles(0))
-            println("----> ", schema_init)
-            println(file)
-            println("----> ", schema)
+            // println(listOfFitsFiles(0))
+            // println("----> ", schema_init)
+            // println(file)
+            // println("----> ", schema)
             throw new AssertionError(
               """
             You are trying to add HDU data with different structures!
@@ -240,13 +239,13 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
         }
         fB.data.close()
       }
+      true
     } else {
       println(s"""
-        FITS type $fitstype not supported yet.
+        FITS type ${fB_init.hduType} not supported yet.
         An empty DataFrame will be returned.""")
+      false
     }
-    // internalSchema = schema
-    fitstype
   }
 
   /**
@@ -261,7 +260,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     *   - (HDFS)  hdfs://<IP>:<PORT>//path/to/data
     *
     *
-    * If the HDU type is not a BINTABLE, return an empty RDD[Row].
+    * If the HDU type is not "implemented", return an empty RDD[Row].
     *
     * @param fn : (String)
     *   Filename of the fits file to be read, or a directory containing FITS files
@@ -277,10 +276,10 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
 
     // Check that all the files have the same Schema
     // in order to perform the union. Return the HDU type.
-    val fitstype = checkSchemaAndReturnType(listOfFitsFiles)
+    val implemented = checkSchemaAndReturnType(listOfFitsFiles)
 
     // Load one or all the FITS files found
-    load(listOfFitsFiles, fitstype)
+    load(listOfFitsFiles, implemented)
   }
 
   /**
@@ -288,7 +287,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     * The structure of the HDU must be the same, that is contain the
     * same number of columns with the same name and element types.
     *
-    * If the HDU type is not a BINTABLE, return an empty RDD[Row].
+    * If the HDU type is not "implemented", return an empty RDD[Row].
     *
     * @param fns : (List[String])
     *   List of filenames with the same structure.
@@ -297,13 +296,13 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     *   Empty if the HDU type is not a BINTABLE.
     *
     */
-  def load(fns : List[String], fitstype: String): RDD[Row] = {
+  def load(fns : List[String], implemented: Boolean): RDD[Row] = {
 
     // Number of files
     val nFiles = fns.size
 
     // Initialise
-    var rdd = if (fitstype == "BINTABLE") {
+    var rdd = if (implemented) {
       loadOneTable(fns(0))
     } else {
       loadOneEmpty
@@ -311,7 +310,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
 
     // Union if more than one file
     for ((file, index) <- fns.slice(1, nFiles).zipWithIndex) {
-      rdd = if (fitstype == "BINTABLE") {
+      rdd = if (implemented) {
         rdd.union(loadOneTable(file))
       } else {
         rdd.union(loadOneEmpty)
@@ -320,7 +319,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     rdd
   }
 
-  /** Load a BinaryTableHDU data contained in one HDU as a RDD[Row].
+  /** Load a xxx FITS data contained in one HDU as a RDD[Row].
     *
     * @param fn : (String)
     *   Path + filename of the fits file to be read.

--- a/src/main/scala/com/sparkfits/FitsSourceRelation.scala
+++ b/src/main/scala/com/sparkfits/FitsSourceRelation.scala
@@ -145,6 +145,8 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     val isDir = fs.isDirectory(path)
     val isFile = fs.isFile(path)
 
+    // println(s"isDir=$isDir isFile=$isFile path=$path")
+
     // List all the files
     val listOfFitsFiles : List[String] = if (isDir) {
       val it = fs.listFiles(path, true)
@@ -211,7 +213,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     val fB_init = new FitsBlock(path_init, conf, indexHDU)
     val fitstype = fB_init.hduType
 
-    val check = if (fitstype == "BINTABLE") {
+    val check = if (fitstype == "BINTABLE" || fitstype == "IMAGE") {
       val schema_init = getSchema(fB_init)
       fB_init.data.close()
 
@@ -224,10 +226,11 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
           case true => isOk
           case false => {
             println(listOfFitsFiles(0))
-            println("----> ",  schema_init)
+            println("----> ", schema_init)
             println(file)
-            println("----> ",  schema)
-            throw new AssertionError("""
+            println("----> ", schema)
+            throw new AssertionError(
+              """
             You are trying to add HDU data with different structures!
             Check that the number of columns, names of columns and element
             types are the same. re-run with .option("verbose", true) to
@@ -332,7 +335,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
 
     // Register header and block boundaries in the Hadoop configuration
     fB.registerHeader()
-    fB.registerBlockBoundaries()
+    fB.blockBoundaries.register(path, conf)
 
     // Check the header if needed
     if (verbosity) {
@@ -389,7 +392,7 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
       // Register header and block boundaries
       // in the Hadoop configuration for later re-use
       fB.registerHeader()
-      fB.registerBlockBoundaries()
+      fB.blockBoundaries.register(pathFS, conf)
       getSchema(fB)
     }
   }

--- a/src/main/scala/com/sparkfits/FitsTable.scala
+++ b/src/main/scala/com/sparkfits/FitsTable.scala
@@ -20,11 +20,32 @@ import scala.util.{Try, Success, Failure}
   */
 object FitsTableLib {
   case class TableInfos() extends FitsLib.Infos {
+
+    def implemented: Boolean = {false}
+
+    def getNRows(keyValues: Map[String, String]) : Long = {0L}
+    def getSizeRowBytes(keyValues: Map[String, String]) : Int = {0}
+    def getNCols(keyValues : Map[String, String]) : Long = {0L}
+    def getColTypes(keyValues : Map[String, String]): List[String] = {null}
+
+    def listOfStruct : List[StructField] = {
+      // Get the list of StructField.
+      val lStruct = List.newBuilder[StructField]
+      /*
+      for (col <- colPositions) {
+        lStruct += readMyType(colNames(col), rowTypes(col))
+      }
+      */
+      lStruct.result
+    }
+
     def getRow(buf: Array[Byte]): List[Any] = {
       var row = List.newBuilder[Any]
 
       row.result
     }
+
+    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {null}
 
     def readMyType(name : String, fitstype : String, isNullable : Boolean = true): StructField = {
       fitstype match {
@@ -36,22 +57,6 @@ object FitsTableLib {
           StructField(name, StringType, isNullable)
         }
       }
-    }
-
-    def getNRows(header : Array[String]) : Long = {0L}
-    def getNCols(header : Array[String]) : Long = {0L}
-    def getColTypes(header : Array[String]): List[String] = {null}
-    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {null}
-
-    def listOfStruct : List[StructField] = {
-      // Get the list of StructField.
-      val lStruct = List.newBuilder[StructField]
-      /*
-      for (col <- colPositions) {
-        lStruct += readMyType(colNames(col), rowTypes(col))
-      }
-      */
-      lStruct.result
     }
   }
 }

--- a/src/main/scala/com/sparkfits/FitsTable.scala
+++ b/src/main/scala/com/sparkfits/FitsTable.scala
@@ -1,0 +1,57 @@
+package com.sparkfits
+
+import java.io.IOError
+import java.nio.ByteBuffer
+import java.io.EOFException
+import java.nio.charset.StandardCharsets
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.FSDataInputStream
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.types._
+
+import scala.util.{Try, Success, Failure}
+
+/**
+  * This is the beginning of a FITS library in Scala.
+  * You will find a large number of methodes to manipulate Binary Table HDUs.
+  * There is no support for image HDU for the moment.
+  */
+object FitsTableLib {
+  case class TableInfos() extends FitsLib.Infos {
+    def getRow(buf: Array[Byte]): List[Any] = {
+      var row = List.newBuilder[Any]
+
+      row.result
+    }
+
+    def readMyType(name : String, fitstype : String, isNullable : Boolean = true): StructField = {
+      fitstype match {
+        case x if fitstype.contains("A") => StructField(name, StringType, isNullable)
+        case _ => {
+          println(s"""FitsTable.readMyType> Cannot infer type $fitstype from the header!
+            See com.sparkfits.FitsSchema.scala
+            """)
+          StructField(name, StringType, isNullable)
+        }
+      }
+    }
+
+    def getNRows(header : Array[String]) : Long = {0L}
+    def getNCols(header : Array[String]) : Long = {0L}
+    def getColTypes(header : Array[String]): List[String] = {null}
+    def getElementFromBuffer(subbuf : Array[Byte], fitstype : String) : Any = {null}
+
+    def listOfStruct : List[StructField] = {
+      // Get the list of StructField.
+      val lStruct = List.newBuilder[StructField]
+      /*
+      for (col <- colPositions) {
+        lStruct += readMyType(colNames(col), rowTypes(col))
+      }
+      */
+      lStruct.result
+    }
+  }
+}

--- a/src/main/scala/com/sparkfits/ReadImage.scala
+++ b/src/main/scala/com/sparkfits/ReadImage.scala
@@ -42,11 +42,6 @@ object ReadImage {
         .option("recordlength", 1 * 1024)   // 1 KB per record
         .load(args(0).toString)             // File to load
 
-      println("show>")
-      df.show()
-      println("printSchema>")
-      df.printSchema()
-
       val count = df.count()
       println("Total rows: " + count.toString)
     }

--- a/src/main/scala/com/sparkfits/ReadImage.scala
+++ b/src/main/scala/com/sparkfits/ReadImage.scala
@@ -21,14 +21,14 @@ import org.apache.spark.sql.functions._
 import org.apache.log4j.Level
 import org.apache.log4j.Logger
 
-object ReadFits {
+object ReadImage {
   // Set to Level.WARN is you want verbosity
   Logger.getLogger("org").setLevel(Level.WARN)
   Logger.getLogger("akka").setLevel(Level.WARN)
 
   val spark = SparkSession
     .builder()
-    .appName("ReadFits")
+    .appName("ReadImage")
     .getOrCreate()
 
   def main(args : Array[String]) = {
@@ -38,7 +38,7 @@ object ReadFits {
       val df = spark.read
         .format("com.sparkfits")
         .option("hdu", hdu)                 // Index of the HDU
-        .option("verbose", true)            // pretty print
+        // .option("verbose", true)            // pretty print
         .option("recordlength", 1 * 1024)   // 1 KB per record
         .load(args(0).toString)             // File to load
 

--- a/src/test/scala/com/sparkfits/FitsLibTest.scala
+++ b/src/test/scala/com/sparkfits/FitsLibTest.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.types._
 
 import com.sparkfits.FitsLib._
 import com.sparkfits.FitsSchema._
+import com.sparkfits.FitsBintableLib._
 
 /**
   * Test class for the FitsSchema object.
@@ -51,15 +52,15 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
   // Check that the HDU asked is below the max HDU index.
   test("FitsLib test: Can you initialise correctly an empty HDU?") {
     val fB1 = new FitsBlock(file, conf, 0)
-    val s = fB1.BlockBoundaries
-    assert(fB1.empty_hdu && s._1 == 0 && s._2 == 2880 && s._3 == 2880 && s._4 == 2880)
+    val s = fB1.blockBoundaries
+    assert(fB1.empty_hdu && s.headerStart == 0 && s.dataStart == 2880 && s.dataStop == 2880 && s.blockStop == 2880)
   }
 
   // Check that the HDU asked is below the max HDU index.
   test("FitsLib test: Can you compute correctly the boundaries of a HDU?") {
     val fB1 = new FitsBlock(file, conf, 1)
-    val s = fB1.BlockBoundaries
-    assert(s._1 == 2880 && s._2 == 5760 && s._3 == 685760 && s._4 == 688320)
+    val s = fB1.blockBoundaries
+    assert(s.headerStart == 2880 && s.dataStart == 5760 && s.dataStop == 685760 && s.blockStop == 688320)
   }
 
   // Check the total number of HDU
@@ -137,9 +138,10 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
 
     // Read the header and set the cursor at the beginning of the data block
     val header = fB1.blockHeader
+    val keyValues = FitsLib.parseHeader(header)
     fB1.resetCursorAtData
 
-    val splitLocations = fB1.splitLocations
+    val splitLocations = fB1.infos.asInstanceOf[BintableInfos].splitLocations
     val ncols = splitLocations.size - 1
 
     var bufferSize: Int = 0
@@ -148,12 +150,14 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
 
     for (pos <- 0 to ncols - 1) {
       // Define an element and read data from the file
-      bufferSize = splitLocations(pos+1) - splitLocations(pos)
+      val col = pos + 1
+      bufferSize = splitLocations(pos + 1) - splitLocations(pos)
       buffer = new Array[Byte](bufferSize)
       fB1.data.readFully(buffer, 0, bufferSize)
 
       // Convert from binary to primitive
-      el = fB1.getElementFromBuffer(buffer, fB1.rowTypes(pos))
+      // shortStringValue(keyValues("TFORM" + (col + 1).toString))
+      el = fB1.infos.getElementFromBuffer(buffer, shortStringValue(keyValues("TFORM" + (pos + 1).toString)))
     }
 
     // The next one should be the beginning of the next row
@@ -162,10 +166,16 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     fB1.data.readFully(buffer, 0, bufferSize)
 
     // Convert from binary to primitive
-    el = fB1.getElementFromBuffer(buffer, fB1.rowTypes(0))
+    el = fB1.infos.getElementFromBuffer(buffer, shortStringValue(keyValues("TFORM" + (1).toString)))
 
     assert(el == "NGC0000001")
   }
+
+  val fB1 = new FitsBlock(file, conf, 1)
+  val header = fB1.blockHeader
+  val coltypes = fB1.infos.getColTypes(header)
+  val s = FitsLib.shortStringValue(coltypes(0))
+  test(s"shortStringValue> coltypes(0)=${coltypes(0)} => $s"){}
 
   // Check the column type conversion
   test("FitsLib test: Can you guess the column types?") {
@@ -175,7 +185,7 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val header = fB1.blockHeader
 
     // Grab the column type (FITS standard)
-    val coltypes = fB1.getColTypes(header)
+    val coltypes = fB1.infos.getColTypes(header)
 
     assert(coltypes(0) == "10A" && coltypes(1) == "E" && coltypes(2) == "D" &&
       coltypes(3) == "K" && coltypes(4) == "J")
@@ -203,11 +213,11 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val header = fB1.blockHeader
 
     // Grab the values as map(keywords/values)
-    val values = fB1.getHeaderValues(header)
+    val keyValues = FitsLib.parseHeader(header)
 
     // Check an entry with a value (BITPIX), and one without.
     // By default, header line without value gets a default value of 0.
-    assert(values("BITPIX").toInt == 8)
+    assert(keyValues("BITPIX").toInt == 8)
   }
 
   // Check the name conversion
@@ -218,11 +228,14 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val header = fB1.blockHeader
 
     // Grab the names as map(keywords/names)
-    val names = fB1.getHeaderNames(header)
+    val keyValues = FitsLib.parseHeader(header)
+
+    val v = keyValues.
+      filter(x => x._2.contains("'"))
 
     // Check an entry with a name (TTYPE1), and one without.
     // By default, header line without name are not taken.
-    assert(names("TTYPE1") == "target" && !names.contains("NAXIS1"))
+    assert(FitsLib.shortStringValue(keyValues("TTYPE1")) == "target" && !v.contains("NAXIS1"))
   }
 
   // Check the comment conversion
@@ -249,8 +262,8 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val header2 = fB2.blockHeader
 
     // Grab the number of rows
-    val nrows1 = fB1.getNRows(header1)
-    val nrows2 = fB2.getNRows(header2)
+    val nrows1 = fB1.infos.getNRows(header1)
+    val nrows2 = fB2.infos.getNRows(header2)
 
     assert(nrows1 == 20000 && nrows2 == 20000)
   }
@@ -265,8 +278,8 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val header2 = fB2.blockHeader
 
     // Grab the number of rows
-    val ncols1 = fB1.getNCols(header1)
-    val ncols2 = fB2.getNCols(header2)
+    val ncols1 = fB1.infos.getNCols(header1)
+    val ncols2 = fB2.infos.getNCols(header2)
 
     assert(ncols1 == 5 && ncols2 == 3)
   }

--- a/src/test/scala/com/sparkfits/FitsLibTest.scala
+++ b/src/test/scala/com/sparkfits/FitsLibTest.scala
@@ -196,6 +196,22 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
 
   }
 
+  test("FitsLib test: what is the recordLength for an image ") {
+    // val file = "src/test/resources/toTest/tst0009.fits"
+    // val hdu = 2
+    val file = "hdfs://134.158.75.222:8020//lsst/images/a.fits"
+    val hdu = 1
+    val fB1 = new FitsBlock(new Path(file), conf, hdu)
+    val header = fB1.blockHeader
+    val keyValue = FitsLib.parseHeader(header)
+    val rowSize = fB1.infos.getSizeRowBytes(keyValue)
+    val nrows = fB1.infos.getNRows(keyValue)
+
+    val startstop = fB1.getBlockBoundaries
+
+    assert(null == s"rowSize=$rowSize nrows=$nrows startstop=${startstop}")
+  }
+
   // Check the header keywords conversion
   test("FitsLib test: Can you grab the keywords of the header?") {
     val fB1 = new FitsBlock(file, conf, 1)

--- a/src/test/scala/com/sparkfits/FitsLibTest.scala
+++ b/src/test/scala/com/sparkfits/FitsLibTest.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.types._
 import com.sparkfits.FitsLib._
 import com.sparkfits.FitsSchema._
 import com.sparkfits.FitsBintableLib._
+import com.sparkfits.FitsImageLib._
 
 /**
   * Test class for the FitsSchema object.
@@ -119,9 +120,10 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
 
     // Read the header and set the cursor at the beginning of the data block
     val header = fB1.blockHeader
+    val keyValues = FitsLib.parseHeader(header)
 
     // Define a row and read data from the file
-    val bufferSize = fB1.getSizeRowBytes(header).toInt
+    val bufferSize = fB1.infos.getSizeRowBytes(keyValues).toInt
     val buffer = new Array[Byte](bufferSize)
     fB1.resetCursorAtData
     fB1.data.readFully(buffer, 0, bufferSize)
@@ -173,7 +175,8 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
 
   val fB1 = new FitsBlock(file, conf, 1)
   val header = fB1.blockHeader
-  val coltypes = fB1.infos.getColTypes(header)
+  val keyValue = FitsLib.parseHeader(header)
+  val coltypes = fB1.infos.getColTypes(keyValue)
   val s = FitsLib.shortStringValue(coltypes(0))
   test(s"shortStringValue> coltypes(0)=${coltypes(0)} => $s"){}
 
@@ -183,9 +186,10 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
 
     // Read the header
     val header = fB1.blockHeader
+    val keyValue = FitsLib.parseHeader(header)
 
     // Grab the column type (FITS standard)
-    val coltypes = fB1.infos.getColTypes(header)
+    val coltypes = fB1.infos.getColTypes(keyValue)
 
     assert(coltypes(0) == "10A" && coltypes(1) == "E" && coltypes(2) == "D" &&
       coltypes(3) == "K" && coltypes(4) == "J")
@@ -262,8 +266,8 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val header2 = fB2.blockHeader
 
     // Grab the number of rows
-    val nrows1 = fB1.infos.getNRows(header1)
-    val nrows2 = fB2.infos.getNRows(header2)
+    val nrows1 = fB1.infos.getNRows(FitsLib.parseHeader(header1))
+    val nrows2 = fB2.infos.getNRows(FitsLib.parseHeader(header2))
 
     assert(nrows1 == 20000 && nrows2 == 20000)
   }
@@ -278,8 +282,8 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val header2 = fB2.blockHeader
 
     // Grab the number of rows
-    val ncols1 = fB1.infos.getNCols(header1)
-    val ncols2 = fB2.infos.getNCols(header2)
+    val ncols1 = fB1.infos.getNCols(FitsLib.parseHeader(header1))
+    val ncols2 = fB2.infos.getNCols(FitsLib.parseHeader(header2))
 
     assert(ncols1 == 5 && ncols2 == 3)
   }
@@ -294,8 +298,8 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     val header2 = fB2.blockHeader
 
     // Grab the number of rows
-    val rowSize1 = fB1.getSizeRowBytes(header1)
-    val rowSize2 = fB2.getSizeRowBytes(header2)
+    val rowSize1 = fB1.infos.getSizeRowBytes(FitsLib.parseHeader(header1))
+    val rowSize2 = fB2.infos.getSizeRowBytes(FitsLib.parseHeader(header2))
 
     assert(rowSize1 == 34 && rowSize2 == 25)
   }

--- a/src/test/scala/com/sparkfits/FitsSchemaTest.scala
+++ b/src/test/scala/com/sparkfits/FitsSchemaTest.scala
@@ -86,8 +86,11 @@ class FitsSchemaTest extends FunSuite with BeforeAndAfterAll {
     assert(col.name == "toto")
   }
 
+  // val keyValues = FitsLib.parseHeader(header1)
+  // test(s"getNCols> keyValues=${keyValues.toString} tfields=${keyValues("TFIELDS")}"){}
+
   test("Schema test: can you generate a list for all columns?") {
-    val ncols = fB1.getNCols(header1)
+    val ncols = fB1.infos.getNCols(header1)
     val myList = ListOfStruct(fB1)
 
     assert(myList.size == ncols)

--- a/src/test/scala/com/sparkfits/FitsSchemaTest.scala
+++ b/src/test/scala/com/sparkfits/FitsSchemaTest.scala
@@ -90,7 +90,7 @@ class FitsSchemaTest extends FunSuite with BeforeAndAfterAll {
   // test(s"getNCols> keyValues=${keyValues.toString} tfields=${keyValues("TFIELDS")}"){}
 
   test("Schema test: can you generate a list for all columns?") {
-    val ncols = fB1.infos.getNCols(header1)
+    val ncols = fB1.infos.getNCols(FitsLib.parseHeader(header1))
     val myList = ListOfStruct(fB1)
 
     assert(myList.size == ncols)

--- a/src/test/scala/com/sparkfits/ReadFitsTest.scala
+++ b/src/test/scala/com/sparkfits/ReadFitsTest.scala
@@ -87,13 +87,13 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   }
 
   // Test if the user provides the data type in the HDU
-  test("HDU type test: Return an empty DataFrame if HDU is an image?") {
+  test("HDU type test: Return the proper record count if HDU is an image?") {
     val fn_image = "src/test/resources/toTest/tst0009.fits"
     val results = spark.read.format("com.sparkfits")
       .option("hdu", 2)
       .load(fn_image)
     val count = results.count()
-    assert(count == 22)
+    assert(count == 155)
   }
 
   // Test if one accesses column as expected for HDU 1

--- a/src/test/scala/com/sparkfits/ReadFitsTest.scala
+++ b/src/test/scala/com/sparkfits/ReadFitsTest.scala
@@ -90,10 +90,10 @@ class ReadFitsTest extends FunSuite with BeforeAndAfterAll {
   test("HDU type test: Return an empty DataFrame if HDU is an image?") {
     val fn_image = "src/test/resources/toTest/tst0009.fits"
     val results = spark.read.format("com.sparkfits")
-    val exception = intercept[AssertionError] {
-      results.option("hdu", 2).load(fn_image)
-    }
-    assert(exception.getMessage.contains("HDU"))
+      .option("hdu", 2)
+      .load(fn_image)
+    val count = results.count()
+    assert(count == 22)
   }
 
   // Test if one accesses column as expected for HDU 1


### PR DESCRIPTION
- FitsBlock now contains a Infos part, that is specific to each Fits data type (Table, Bintable, Image)
- The generic Infos structure is defined as a Trait defining few generic accessors.
- Specific implementations of Infos are available in specific FitsXxx files
- the parsing of Headers is completely generic, we don't differentiate names, numeric values.
  Parsing provides a Map of (Key, value)

The SourceRelation & RecordReader are not yet adapted to Image data format.

WARNING:
1) (the changes are proposed as a new branch "images" for safety reasons)
2) (the restructured code still needs lots of cleanup)
3) (not yet completed as of the image reading)
4) (the "sbt test" is ok except one test on the empty result when reading an image)

CA
